### PR TITLE
[#67] 백엔드 mongoDB 연동

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,6 +8,7 @@
     "swagger-auto": "ts-node src/docs/swaggerAutogen.ts"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "mongoose": "^8.8.0"
   },

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -2,8 +2,16 @@ import express from 'express';
 import routes from './routes/v1/index';
 import { swaggerUi } from './docs/swagger';
 import swaggerDocument from './docs/swagger-output.json';
+import mongoose from 'mongoose';
+import 'dotenv/config';
 
 const app = express();
+
+mongoose.connect(
+  process.env.MONGO_URI||""
+)
+  .then(() => console.log('MongoDB connected'))
+  .catch((err) => { console.log(err) })
 
 // 미들웨어 설정
 app.use(express.json());

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -2,16 +2,9 @@ import express from 'express';
 import routes from './routes/v1/index';
 import { swaggerUi } from './docs/swagger';
 import swaggerDocument from './docs/swagger-output.json';
-import mongoose from 'mongoose';
-import 'dotenv/config';
+import './config/dbConnection';
 
 const app = express();
-
-mongoose.connect(
-  process.env.MONGO_URI||""
-)
-  .then(() => console.log('MongoDB connected'))
-  .catch((err) => { console.log(err) })
 
 // 미들웨어 설정
 app.use(express.json());

--- a/apps/server/src/config/dbConnection.ts
+++ b/apps/server/src/config/dbConnection.ts
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+import 'dotenv/config';
+
+mongoose
+  .connect(process.env.MONGO_URI || '')
+  .then(() => console.log('MongoDB connected'))
+  .catch((err) => {
+    console.log(err);
+  });

--- a/apps/server/src/controllers/exampleController.ts
+++ b/apps/server/src/controllers/exampleController.ts
@@ -1,0 +1,87 @@
+import { Request, Response } from 'express';
+import { createTodo, getTodoById, getAllTodos, updateTodoById, deleteTodoById } from '../services/exampleService';
+
+export const createTodoController = async (req: Request, res: Response): Promise<void> => {
+  /* 
+    #swagger.summary = '새로운 Todo 생성'
+    #swagger.description = '새로운 todo 항목을 생성합니다.'
+    #swagger.tags = ['Todos']
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/Todo" 
+          }
+        }
+      }
+    }
+    #swagger.responses[201] = {
+      description: 'Todo 생성 성공',
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/Todo"
+          }
+        }
+      }
+    }
+    #swagger.responses[500] = {
+      description: '서버 에러'
+    }
+  */
+  try {
+    const todo = await createTodo(req.body);
+    res.status(201).json(todo);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getTodoByIdController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const todoId = parseInt(req.params.todoid, 10);
+    const todo = await getTodoById(todoId);
+    if (!todo) {
+      res.status(404).json({ message: 'Todo not found' });
+    }
+    res.status(200).json(todo);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getAllTodosController = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const todos = await getAllTodos();
+    res.status(200).json(todos);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const updateTodoByIdController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const todoId = parseInt(req.params.todoid, 10);
+    const updatedTodo = await updateTodoById(todoId, req.body);
+    if (!updatedTodo) {
+      res.status(404).json({ message: 'Todo not found' });
+    }
+    res.status(200).json(updatedTodo);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const deleteTodoByIdController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const todoId = parseInt(req.params.todoid, 10);
+    const deletedTodo = await deleteTodoById(todoId);
+    if (!deletedTodo) {
+      res.status(404).json({ message: 'Todo not found' });
+    }
+    res.status(200).json({ message: 'Todo deleted successfully' });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/apps/server/src/docs/swagger-output.json
+++ b/apps/server/src/docs/swagger-output.json
@@ -1,13 +1,9 @@
 {
-  "swagger": "2.0",
   "info": {
     "version": "1.0.0",
     "title": "REST API",
     "description": ""
   },
-  "host": "localhost:3000",
-  "basePath": "/",
-  "schemes": ["http"],
   "paths": {
     "/welcome": {
       "get": {
@@ -28,21 +24,155 @@
           }
         }
       }
+    },
+    "/todos": {
+      "post": {
+        "tags": [
+          "Todos"
+        ],
+        "summary": "새로운 Todo 생성",
+        "description": "새로운 todo 항목을 생성합니다.",
+        "responses": {
+          "201": {
+            "description": "Todo 생성 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Todo"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 에러"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Todo"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/todos/{todoid}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "todoid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "todoid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "todoid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
     }
   },
-  "swaggerDefinition": {
-    "openapi": "3.0.0",
-    "info": {
-      "title": "BooLock API",
-      "version": "0.1.0",
-      "description": "BooLock API with express"
-    },
-    "servers": [
-      {
-        "url": "localhost:3000"
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "http://localhost:3000/"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Todo": {
+        "type": "object",
+        "properties": {
+          "todoid": {
+            "type": "integer",
+            "example": 1
+          },
+          "content": {
+            "type": "string",
+            "example": "Sample todo content"
+          },
+          "completed": {
+            "type": "string",
+            "example": "false"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-11-07T00:00:00.000Z"
+          }
+        },
+        "required": [
+          "todoid",
+          "content"
+        ]
       }
-    ],
-    "basePath": "/"
-  },
-  "apis": ["./src/routes/v1/*.ts", "/src/docs/*.yaml"]
+    }
+  }
 }

--- a/apps/server/src/docs/swagger.ts
+++ b/apps/server/src/docs/swagger.ts
@@ -9,12 +9,29 @@ const options = {
       version: '0.1.0',
       description: 'BooLock API with express',
     },
-    servers: [{ url: 'localhost:3000' }],
-    basePath: '/',
+    servers: [
+      {
+        url: 'http://localhost:3000',
+      },
+    ],
+    components: {
+      schemas: {
+        Todo: {
+          type: 'object',
+          properties: {
+            todoid: { type: 'integer', example: 1 },
+            content: { type: 'string', example: 'Sample todo content' },
+            completed: { type: 'string', example: 'false' },
+            created: { type: 'string', format: 'date-time', example: '2024-11-07T00:00:00.000Z' },
+          },
+          required: ['todoid', 'content'],
+        },
+      },
+    },
   },
-  apis: ['./src/routes/v1/*.ts', '/src/docs/*.yaml'],
+  apis: ['./src/routes/v1/*.ts', './src/docs/*.yaml'],
 };
 
 const specs = swaggerJsdoc(options);
 
-export { options, swaggerUi, specs };
+export { options, swaggerUi, specs};

--- a/apps/server/src/docs/swaggerAutogen.ts
+++ b/apps/server/src/docs/swaggerAutogen.ts
@@ -1,4 +1,5 @@
 import swaggerAutogen from 'swagger-autogen';
+import fs from 'fs';
 import { options } from './swagger';
 
 const outputFile = './src/docs/swagger-output.json';
@@ -7,5 +8,37 @@ const endpointsFiles = ['./src/routes/v1/index.ts'];
 const swaggerAutogenInstance = swaggerAutogen();
 
 swaggerAutogenInstance(outputFile, endpointsFiles, options).then(() => {
-  console.log('Swagger documentation generated');
+  console.log('Swagger documentation generated in Swagger 2.0 format');
+
+  fs.readFile(outputFile, 'utf8', (err, data) => {
+    if (err) throw err;
+
+    let swaggerDoc = JSON.parse(data);
+
+    swaggerDoc.openapi = '3.0.0';
+    delete swaggerDoc.swagger;
+
+    if (swaggerDoc.host && swaggerDoc.basePath) {
+      swaggerDoc.servers = [
+        {
+          url: `http://${swaggerDoc.host}${swaggerDoc.basePath}`
+        }
+      ];
+    }
+    delete swaggerDoc.host;
+    delete swaggerDoc.basePath;
+    delete swaggerDoc.schemes;
+
+    if (swaggerDoc.swaggerDefinition && swaggerDoc.swaggerDefinition.components) {
+      swaggerDoc.components = swaggerDoc.swaggerDefinition.components;
+    }
+    delete swaggerDoc.swaggerDefinition;
+
+    delete swaggerDoc.apis;
+
+    fs.writeFile(outputFile, JSON.stringify(swaggerDoc, null, 2), (err) => {
+      if (err) throw err;
+      console.log('Swagger document successfully converted to OpenAPI 3.0 format');
+    });
+  });
 });

--- a/apps/server/src/models/exampleModel.ts
+++ b/apps/server/src/models/exampleModel.ts
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+const todoSchema = new mongoose.Schema({
+  todoid: { type: Number, required: true, unique: true },
+  content: { type: String, required: true },
+  completed: { type: String, default: false }
+}, {
+  timestamps:true
+});
+
+const Todo = mongoose.model('Todo', todoSchema, 'todos');
+
+export default Todo;

--- a/apps/server/src/routes/v1/exampleRoute.ts
+++ b/apps/server/src/routes/v1/exampleRoute.ts
@@ -1,4 +1,11 @@
 import express from 'express';
+import {
+  createTodoController,
+  getTodoByIdController,
+  getAllTodosController,
+  updateTodoByIdController,
+  deleteTodoByIdController,
+} from '../../controllers/exampleController'
 
 const router = express.Router();
 
@@ -9,5 +16,16 @@ router.route('/welcome').get((req, res) => {
 router.route('/test').get((req, res) => {
   res.send('test');
 });
+
+router.post('/todos', createTodoController);
+
+router.get('/todos/:todoid', getTodoByIdController);
+
+router.get('/todos', getAllTodosController);
+
+router.put('/todos/:todoid', updateTodoByIdController);
+
+router.delete('/todos/:todoid', deleteTodoByIdController);
+
 
 export default router;

--- a/apps/server/src/services/exampleService.ts
+++ b/apps/server/src/services/exampleService.ts
@@ -1,0 +1,59 @@
+import Todo from "../models/exampleModel";
+import { Document } from 'mongoose';
+
+type TodoType = {
+  todoid: number;
+  content: string;
+  completed?: string;
+}
+
+type TodoDocumentType = TodoType & Document;
+
+export const createTodo = async (data:TodoType): Promise<TodoDocumentType> => {
+  try {
+    const todo = new Todo(data);
+    const savedTodo = await todo.save();
+    return savedTodo;
+  } catch (error:any) {
+    throw new Error(`Error creating todo: ${error.message}`);
+  }
+};
+
+export const getTodoById = async (todoid: number): Promise<TodoDocumentType|null> => {
+  try {
+    const todo = await Todo.findOne({ todoid });
+    return todo;
+  } catch (error:any) {
+    throw new Error(`Error finding todo with id ${todoid}: ${error.message}`);
+  }
+};
+
+export const getAllTodos = async () : Promise<TodoDocumentType[]> => {
+  try {
+    const todos = await Todo.find();
+    return todos;
+  } catch (error:any) {
+    throw new Error(`Error retrieving todos: ${error.message}`);
+  }
+};
+
+export const updateTodoById = async (todoid:number, updateData:Partial<TodoType>): Promise<TodoDocumentType|null> => {
+  try {
+    const updatedTodo = await Todo.findOneAndUpdate({ todoid }, updateData, {
+      new: true,
+      runValidators: true
+    });
+    return updatedTodo;
+  } catch (error:any) {
+    throw new Error(`Error updating todo with id ${todoid}: ${error.message}`);
+  }
+};
+
+export const deleteTodoById = async (todoid:number): Promise<TodoDocumentType | null>  => {
+  try {
+    const deletedTodo = await Todo.findOneAndDelete({ todoid });
+    return deletedTodo;
+  } catch (error:any) {
+    throw new Error(`Error deleting todo with id ${todoid}: ${error.message}`);
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
 
   apps/server:
     dependencies:
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       express:
         specifier: ^4.21.1
         version: 4.21.1
@@ -1598,6 +1601,10 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -4518,6 +4525,8 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
 


### PR DESCRIPTION
## 🔗#67

## 🙋‍ Summary (요약) 
- Cloud DB for MongoDB 세팅
- mongoDB 연동
- 샘플용 crud 코드 생성
- 스웨거 문서 관련 수정

## 😎 Description (변경사항)
### Cloud DB for MongoDB 세팅
- boolock_test 라는 vpc를 하나 만들고, 하위에 public, private 서브넷을 하나씩 만들었습니다. 

- mongoDB는 private subnet에 위치시켰습니다.

  - 그럼 왜 public도 만들었는지? : 해당 vpc는 이후 테스트용 배포버전에서도 사용하기 위해서 server 인스턴스를 위치시킬 공간으로 만들어두었습니다.
  
- 약간의 트러블슈팅 과정이 있었으나 결론적으로 ssl vpn을 생성하여 vpn 접속 후 db 연동을 하는 방식으로 진행하게 되었습니다.
  - vpn 접속 시간에 대한 유효 시간도 존재하고, otp로 2차 인증까지 해야하는 불편한 세팅과정을 필요케하여 죄송합니다ㅠㅠ..

- 연동 세팅은 슬랙 팀 dm에 올린 메시지대로 진행해주시면 됩니다:) (env 설정값에 대해 약간 변동사항이 있어서 이미 설정하신 분들은 확인 후 다시 설정해주시길 바랍니다)

### mongoDB 연동
- env 파일 설정은 변경사항이 있을 때마다 말씀드리겠습니다. 

``` jsx
// apps/server/app.tsx

mongoose.connect(
  process.env.MONGO_URI||""
)
  .then(() => console.log('MongoDB connected'))
  .catch((err) => { console.log(err) })
```

- db 연동에 대한 코드는 위 코드가 전부입니다.

- 코드 볼륨이 크지 않아 별도의 db 연동을 하는 파일을 추가적으로 만들지 않아도 되겠다고 판단하여 app.tsx 파일에 추가해두었습니다.

![image](https://github.com/user-attachments/assets/f78fc869-b87b-4e29-8c23-3e4c2bed5316)

- 연동이 성공적으로 되면 `MongoDB connected` 로그가 뜹니다. (안뜨면 얘기해주세요)

- **다른 파일에 둬야한다면 말씀해주세요!**

### 샘플용 crud 코드 생성
- 실제 db에 데이터 올라가는 것도 확인하고, 샘플 코드가 가이드처럼 있으면 좋겠다고 생각하여, example 파일에다가 샘플용 crud 코드를 만들어두었습니다. (gpt의 힘을 빌려..)

- 정말 단순히 샘플용 코드라고 생각하였기에 실제 저희가 써야하는 db 설정을 추가해두면 혼선이 생길까봐 todos 라는 별도의 컬렉션을 만들어 사용하였습니다.

- 이외 mongoose 사용 방식에 대해서는 https://poiemaweb.com/mongoose 해당 사이트에 잘 정리되어 있으니 참고바랍니다!

###  스웨거 문서 관련 수정
- autogen을 실행하고 돌려봤을 때, request, response body나 이외의 스키마, 응답 형식 등에 대한 정보가 제대로 작성되어있지 않아 형식을 조금 수정하였습니다. (처리했던 과정은 트러블슈팅에 있습니다.)

- 컨트롤러 함수에 일일이 주석처리로 스웨거 문서에 필요한 정보들을 주입해주지 않으면 문서 작성이 제대로 이루어지지 않습니다.

``` jsx
export const createTodoController = async (req: Request, res: Response): Promise<void> => {
  /* 
    #swagger.summary = '새로운 Todo 생성'
    #swagger.description = '새로운 todo 항목을 생성합니다.'
    #swagger.tags = ['Todos']
    #swagger.requestBody = {
      required: true,
      content: {
        "application/json": {
          schema: {
            $ref: "#/components/schemas/Todo" 
          }
        }
      }
    }
    #swagger.responses[201] = {
      description: 'Todo 생성 성공',
      content: {
        "application/json": {
          schema: {
            $ref: "#/components/schemas/Todo"
          }
        }
      }
    }
    #swagger.responses[500] = {
      description: '서버 에러'
    }
  */
  try {
    const todo = await createTodo(req.body);
    res.status(201).json(todo);
  } catch (error: any) {
    res.status(500).json({ message: error.message });
  }
};
```

- 이런 형식으로 반드시 작성해주어야합니다. (제가 알기론.. 아마 다른.. 프레임워크도 스웨거 문서화할 때는 데코레이터로 세세한 설정을 해주긴 해야하는 걸로 압니다.)

- 주석처리를 해줌에도 불구하고 스웨거 문서에 반영되지 않았던 문제점을 해결하였습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
### ncp에서 db 세팅을 하며 겪었던 고난과.. 역경..
[[BooLock 위키 - 나는 BE 개발자 분들을 존경한다. (1)]](https://laced-riverbed-47c.notion.site/BE-1-507fd1641d3b46208421242ccfffe44f?pvs=4)
_(겪었던 트러블 슈팅에 대한 자세한 사항은 여기에다가 천천히 적어두겠습니다)_

- DB가 public 영역에서 만들어진 것이 아니기 때문에 팀원 모두의 개별적인 개발환경에서 접근할 수 있게 하는 방법에 대해 ncp 공식문서에서 2가지 시나리오를 소개해주었습니다.

  1. nat gateway를 이용해서 공인 ip를 받고 이 ip로 접근해서 db와 연동시키는 방법
  2. ssl vpn을 생성해서 사용자를 등록하고 해당 vpn에 접속 후 연동하는 방법
  
- 원래는 공인 ip를 받아서 별도의 vpn 접속을 하지 않아도 연동할 수 있게 하고 싶었습니다. (실제 공인 ip와 db에 대한 계정 정보는 env에 저장해둘 것이니 2번째 방법에 비해 보안에 취약하다고 해도 괜찮을 것이라고 생각했습니다.~(뭐 어차피 테스트이기도 하고..)~)
   하지만 해당 설정을 해도 계속 db 연동이 되지 않아서 ssl vpn 발급받는 걸로 변경했습니다. (오히려 보안에 더 좋으니 럭키비키잖아🍀?

###  스웨거 문서 관련 수정
[[BooLock 위키 - 스웨거는 express에게 불친절하다.]](https://laced-riverbed-47c.notion.site/express-ea250a4efbf94f8e816be833ed2f0e5a?pvs=4)
- 내용이 너무 길어져서 해당 트러블슈팅또한 별도의 문서로 정리하였습니다.

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
- 영재님이 부탁하셨던 워크스페이스 이름 변경용 데이터같은 경우, 저희가 만든 데이터 스키마 형태가 다른 워크스페이스 정보까지 포함되어있는 볼륨이 좀 큰 형태라고 생각하였기에 아직 추가해두진 않았습니다. 데일리 스크럼 후 별도로 논의