### PR TITLE
[#83] db 연동 구조 변경 및 코드 수정

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
-    "mongoose": "^8.8.0"
+    "mongoose": "^8.8.0",
+    "tunnel-ssh": "^5.1.2"
   },
   "devDependencies": {
     "@packages/tsconfig": "workspace:*",

--- a/apps/server/src/config/dbConnection.ts
+++ b/apps/server/src/config/dbConnection.ts
@@ -1,9 +1,48 @@
 import mongoose from 'mongoose';
 import 'dotenv/config';
+import { createTunnel } from 'tunnel-ssh';
 
-mongoose
-  .connect(process.env.MONGO_URI || '')
-  .then(() => console.log('MongoDB connected'))
-  .catch((err) => {
-    console.log(err);
-  });
+const setDbConnection = async () => {
+  const tunnelOptions = {
+    autoClose: true,
+  };
+
+  const sshOptions = {
+    host: process.env.SSH_HOST,
+    port: process.env.SSH_PORT,
+    username: process.env.SSH_USER,
+    password: process.env.SSH_PASSWORD,
+  };
+
+  const serverOptions = {
+    port: parseInt(process.env.LOCAL_PORT || '27018', 10) || 27018,
+  };
+
+  const forwardOptions = {
+    dstAddr: process.env.SSH_DATABASE_HOST,
+    dstPort: parseInt(process.env.SSH_DATABASE_PORT || '27017', 10),
+  };
+
+  try {
+    const [server, client] = await createTunnel(
+      tunnelOptions,
+      serverOptions,
+      sshOptions,
+      forwardOptions
+    );
+
+    const address = server.address();
+    if (address && typeof address !== 'string') {
+      console.log(`SSH 터널이 수신 대기 중입니다.`);
+
+      await mongoose.connect(process.env.MONGO_URI || '');
+      console.log('MongoDB에 성공적으로 연결되었습니다.');
+    } else {
+      console.error('서버 주소를 가져올 수 없습니다.');
+    }
+  } catch (error) {
+    console.error('SSH 터널링 오류:', error);
+  }
+};
+
+setDbConnection();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       mongoose:
         specifier: ^8.8.0
         version: 8.8.0
+      tunnel-ssh:
+        specifier: ^5.1.2
+        version: 5.1.2
     devDependencies:
       '@packages/tsconfig':
         specifier: workspace:*
@@ -1320,6 +1323,9 @@ packages:
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1347,6 +1353,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -1385,6 +1394,10 @@ packages:
   bson@6.9.0:
     resolution: {integrity: sha512-X9hJeyeM0//Fus+0pc5dSUMhhrrmWwQUtdavaQeF3Ta6m69matZkGWV/MrBcnwUeLC8W9kwwc2hfkZgUuCX3Ig==}
     engines: {node: '>=16.20.1'}
+
+  buildcheck@0.0.6:
+    resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
+    engines: {node: '>=10.0.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1496,6 +1509,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -2268,6 +2285,9 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nan@2.22.0:
+    resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2735,6 +2755,10 @@ packages:
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
+  ssh2@1.16.0:
+    resolution: {integrity: sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==}
+    engines: {node: '>=10.16.0'}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -2900,8 +2924,14 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tunnel-ssh@5.1.2:
+    resolution: {integrity: sha512-PNfxgg5aEV9ZWpx4oHvkyPoC7TvYGdbob9L35BrYGY/LM3mt5KUQ5uOO9PbT/gNQowGanOfli3JGwRZ+DTd2ZQ==}
+
   tween-functions@1.2.0:
     resolution: {integrity: sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4283,6 +4313,10 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
@@ -4314,6 +4348,10 @@ snapshots:
       - debug
 
   balanced-match@1.0.2: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   better-opn@3.0.2:
     dependencies:
@@ -4370,6 +4408,9 @@ snapshots:
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
 
   bson@6.9.0: {}
+
+  buildcheck@0.0.6:
+    optional: true
 
   bytes@3.1.2: {}
 
@@ -4464,6 +4505,12 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.6.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.6
+      nan: 2.22.0
+    optional: true
 
   create-require@1.1.1: {}
 
@@ -5254,6 +5301,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nan@2.22.0:
+    optional: true
+
   nanoid@3.3.7: {}
 
   natural-compare@1.4.0: {}
@@ -5674,6 +5724,14 @@ snapshots:
     dependencies:
       memory-pager: 1.5.0
 
+  ssh2@1.16.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.22.0
+
   statuses@2.0.1: {}
 
   storybook@8.4.1(prettier@3.3.3):
@@ -5867,7 +5925,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tunnel-ssh@5.1.2:
+    dependencies:
+      ssh2: 1.16.0
+
   tween-functions@1.2.0: {}
+
+  tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## 🔗 Linked Issue #83 

## 🙋‍ Summary (요약) 
- cloud DB -> server instance 내 DB 설정으로 변경
-  ssh 설정 및 db 연동 코드 추가

## 😎 Description (변경사항)
### cloud DB -> server instance 내 DB 설정으로 변경
![image](https://github.com/user-attachments/assets/5baa5e20-6f3a-4a31-bcc6-b6d25753af31)
[(감사합니다 web03팀 캠퍼분들..)](https://github.com/boostcampwm-2024/web03-CorinEE/wiki/%5BBE%5D-ssh%ED%84%B0%EB%84%90%EB%A7%81%EC%9C%BC%EB%A1%9C--db%EC%97%B0%EA%B2%B0) (아키텍쳐 이미지도 추후 바꿀게요..)

- 기존에 ncp의 cloud DB for MongoDB 라는 클라우드 DB를 사용하는 방식에서, private server instacne를 생성하고 이 내부에 mongoDB를 구축 한 후 ssh 터널링을 통해 db를 연동하는 방식으로 변경하였습니다.

### ssh 설정 및 db 연동 코드 추가
- 기존의 db 연동 코드를 사용하려면, 터미널창에서 ssh 터널링 환경으로 세팅해두고 연결을 시도해야합니다. 
- 계속 개발을 진행할 때마다, 로컬에서 터널링을 설정하고 연결해야하는 번거로움을 없애고자 tunnel-ssh 패키지를 활용하여 아예 서버를 실행할 때마다 ssh 터널링을 통해 db에 접근할 수 있게 설정해주었습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
<추후 작성... 예정..>

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
