### PR TITLE
[🚨 !HOTFIX!] swagger autogen이 주석처리 설정을 못읽어오던 오류 해결

### DIFF
--- a/apps/server/src/controllers/exampleController.ts
+++ b/apps/server/src/controllers/exampleController.ts
@@ -1,35 +1,13 @@
 import { Request, Response } from 'express';
-import { createTodo, getTodoById, getAllTodos, updateTodoById, deleteTodoById } from '../services/exampleService';
+import {
+  createTodo,
+  getTodoById,
+  getAllTodos,
+  updateTodoById,
+  deleteTodoById,
+} from '../services/exampleService';
 
 export const createTodoController = async (req: Request, res: Response): Promise<void> => {
-  /* 
-    #swagger.summary = '새로운 Todo 생성'
-    #swagger.description = '새로운 todo 항목을 생성합니다.'
-    #swagger.tags = ['Todos']
-    #swagger.requestBody = {
-      required: true,
-      content: {
-        "application/json": {
-          schema: {
-            $ref: "#/components/schemas/Todo" 
-          }
-        }
-      }
-    }
-    #swagger.responses[201] = {
-      description: 'Todo 생성 성공',
-      content: {
-        "application/json": {
-          schema: {
-            $ref: "#/components/schemas/Todo"
-          }
-        }
-      }
-    }
-    #swagger.responses[500] = {
-      description: '서버 에러'
-    }
-  */
   try {
     const todo = await createTodo(req.body);
     res.status(201).json(todo);

--- a/apps/server/src/controllers/workspaceController.ts
+++ b/apps/server/src/controllers/workspaceController.ts
@@ -6,31 +6,6 @@ import { WorkspaceService } from '@/services/workspaceService';
 export const WorkspaceController = () => {
   const workspaceService = WorkspaceService();
   const createNewWorkspace = async (req: Request, res: Response) => {
-    /* 
-  #swagger.summary = '새로운 워크스페이스 생성'
-  #swagger.description = '새로운 워크스페이스를 생성합니다.'
-  #swagger.tags = ['Workspace']
-  #swagger.responses[201] = {
-    description: 'success',
-    content: {
-      "application/json": {
-        schema: {
-          type: "object",
-          properties: {
-            newWorkspaceId: {
-              type: "string",
-              example: "b15eac31-3942-4192-9cbd-2e2cdd48da0a"
-            }
-          }
-        }
-      }
-    }
-  }
-  #swagger.responses[500] = {
-    description: 'internal server error'
-  }
-*/
-
     try {
       const newWorkspaceId = await workspaceService.createWorkspace();
       res.status(201).json({ newWorkspaceId });

--- a/apps/server/src/docs/swagger-output.json
+++ b/apps/server/src/docs/swagger-output.json
@@ -137,6 +137,30 @@
           }
         }
       }
+    },
+    "/workspace/": {
+      "post": {
+        "tags": [
+          "Workspace"
+        ],
+        "summary": "새로운 워크스페이스 생성",
+        "description": "새로운 워크스페이스를 생성합니다.",
+        "responses": {
+          "201": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error"
+          }
+        }
+      }
     }
   },
   "openapi": "3.0.0",
@@ -171,6 +195,34 @@
         "required": [
           "todoid",
           "content"
+        ]
+      },
+      "Workspace": {
+        "type": "object",
+        "properties": {
+          "workspace_id": {
+            "type": "string",
+            "example": "b15eac31-3942-4192-9cbd-2e2cdd48da0a"
+          },
+          "name": {
+            "type": "string",
+            "example": "워크스페이스 이름",
+            "default": "워크스페이스 이름"
+          },
+          "thumbnail": {
+            "type": "string",
+            "example": "https://example.com/thumbnail.png"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-11-07T00:00:00.000Z"
+          }
+        },
+        "required": [
+          "workspace_id",
+          "name",
+          "updated_at"
         ]
       }
     }

--- a/apps/server/src/docs/swagger.ts
+++ b/apps/server/src/docs/swagger.ts
@@ -26,6 +26,30 @@ const options = {
           },
           required: ['todoid', 'content'],
         },
+        Workspace: {
+          type: 'object',
+          properties: {
+            workspace_id: {
+              type: 'string',
+              example: 'b15eac31-3942-4192-9cbd-2e2cdd48da0a',
+            },
+            name: {
+              type: 'string',
+              example: '워크스페이스 이름',
+              default: '워크스페이스 이름',
+            },
+            thumbnail: {
+              type: 'string',
+              example: 'https://example.com/thumbnail.png',
+            },
+            updated_at: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-11-07T00:00:00.000Z',
+            },
+          },
+          required: ['workspace_id', 'name', 'updated_at'],
+        },
       },
     },
   },
@@ -34,4 +58,4 @@ const options = {
 
 const specs = swaggerJsdoc(options);
 
-export { options, swaggerUi, specs};
+export { options, swaggerUi, specs };

--- a/apps/server/src/docs/swaggerAutogen.ts
+++ b/apps/server/src/docs/swaggerAutogen.ts
@@ -21,8 +21,8 @@ swaggerAutogenInstance(outputFile, endpointsFiles, options).then(() => {
     if (swaggerDoc.host && swaggerDoc.basePath) {
       swaggerDoc.servers = [
         {
-          url: `http://${swaggerDoc.host}${swaggerDoc.basePath}`
-        }
+          url: `http://${swaggerDoc.host}${swaggerDoc.basePath}`,
+        },
       ];
     }
     delete swaggerDoc.host;

--- a/apps/server/src/routes/v1/exampleRoute.ts
+++ b/apps/server/src/routes/v1/exampleRoute.ts
@@ -5,7 +5,7 @@ import {
   getAllTodosController,
   updateTodoByIdController,
   deleteTodoByIdController,
-} from '../../controllers/exampleController'
+} from '../../controllers/exampleController';
 
 const router = express.Router();
 
@@ -17,7 +17,38 @@ router.route('/test').get((req, res) => {
   res.send('test');
 });
 
-router.post('/todos', createTodoController);
+router.post(
+  '/todos',
+  createTodoController
+  /* 
+    #swagger.summary = '새로운 Todo 생성'
+    #swagger.description = '새로운 todo 항목을 생성합니다.'
+    #swagger.tags = ['Todos']
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/Todo" 
+          }
+        }
+      }
+    }
+    #swagger.responses[201] = {
+      description: 'Todo 생성 성공',
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/Todo"
+          }
+        }
+      }
+    }
+    #swagger.responses[500] = {
+      description: '서버 에러'
+    }
+  */
+);
 
 router.get('/todos/:todoid', getTodoByIdController);
 
@@ -26,6 +57,5 @@ router.get('/todos', getAllTodosController);
 router.put('/todos/:todoid', updateTodoByIdController);
 
 router.delete('/todos/:todoid', deleteTodoByIdController);
-
 
 export default router;

--- a/apps/server/src/routes/v1/workspaceRoute.ts
+++ b/apps/server/src/routes/v1/workspaceRoute.ts
@@ -5,4 +5,25 @@ export const workspaceRouter = express.Router();
 
 const workspaceController = WorkspaceController();
 
-workspaceRouter.post('/', workspaceController.createNewWorkspace);
+workspaceRouter.post(
+  '/',
+  workspaceController.createNewWorkspace
+  /* 
+    #swagger.summary = '새로운 워크스페이스 생성'
+    #swagger.description = '새로운 워크스페이스를 생성합니다.'
+    #swagger.tags = ['Workspace']
+    #swagger.responses[201] = {
+      description: 'success',
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/Workspace"
+          }
+        }
+      }
+    }
+    #swagger.responses[500] = {
+      description: 'internal server error'
+    }
+  */
+);


### PR DESCRIPTION
## 🙋‍ Summary (요약) 
- swagger autogen이 주석처리 설정을 못읽어오던 오류 해결

## 😎 Description (변경사항)
### swagger autogen이 주석처리 설정을 못읽어오던 오류 해결
- 주석처리 위치를 controller에서 router로 옮겼습니다.
- 기존 example 코드들은 바로 `/` 경로로 넘어갔기에 controller 함수 내에서의 주석처리를 잘 읽어왔던 것 같은데, `/workspace/` 경로를 한번 끼고 나니 workspace controller 함수 내 스웨거 설정 주석은 잘 못 읽어오는 것 같습니다.
```js
workspaceRouter.post(
  '/',
  workspaceController.createNewWorkspace
  /* 
    #swagger.summary = '새로운 워크스페이스 생성'
    #swagger.description = '새로운 워크스페이스를 생성합니다.'
...
)
```
- 이런식으로 아예 router에서 controller 함수 매핑해줄 때, controller 설정 뒤에 바로 스웨거 설정 주석을 덧붙여주는 것으로 변경했습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
