### PR TITLE
[#96] db연동시 로컬/배포환경 분리를 위한 로직 추가

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,11 +1,11 @@
 FROM base-image AS backend-build
+
 WORKDIR /app/apps/server
+
 COPY ./apps/server .
 COPY --from=base-image /app/packages /app/packages
+
 RUN pnpm install --offline --frozen-lockfile
 RUN pnpm run build
 
-FROM node:20-alpine AS backend
-WORKDIR /app
-COPY --from=backend-build /app/apps/server/dist ./
 CMD ["pnpm", "run", "start"]

--- a/apps/server/src/config/dbConnection.ts
+++ b/apps/server/src/config/dbConnection.ts
@@ -3,45 +3,50 @@ import 'dotenv/config';
 import { createTunnel } from 'tunnel-ssh';
 
 const setDbConnection = async () => {
-  const tunnelOptions = {
-    autoClose: true,
-  };
+  const isLocal = process.env.IS_LOCAL === 'true';
 
-  const sshOptions = {
-    host: process.env.SSH_HOST,
-    port: process.env.SSH_PORT,
-    username: process.env.SSH_USER,
-    password: process.env.SSH_PASSWORD,
-  };
+  if (isLocal) {
+    const tunnelOptions = {
+      autoClose: true,
+    };
 
-  const serverOptions = {
-    port: parseInt(process.env.LOCAL_PORT || '27018', 10) || 27018,
-  };
+    const sshOptions = {
+      host: process.env.SSH_HOST,
+      port: process.env.SSH_PORT,
+      username: process.env.SSH_USER,
+      password: process.env.SSH_PASSWORD,
+    };
 
-  const forwardOptions = {
-    dstAddr: process.env.SSH_DATABASE_HOST,
-    dstPort: parseInt(process.env.SSH_DATABASE_PORT || '27017', 10),
-  };
+    const serverOptions = {
+      port: parseInt(process.env.LOCAL_PORT || '27018', 10) || 27018,
+    };
+
+    const forwardOptions = {
+      dstAddr: process.env.SSH_DATABASE_HOST,
+      dstPort: parseInt(process.env.SSH_DATABASE_PORT || '27017', 10),
+    };
+
+    try {
+      const [server] = await createTunnel(tunnelOptions, serverOptions, sshOptions, forwardOptions);
+
+      const address = server.address();
+      if (address && typeof address !== 'string') {
+        console.log(`SSH 터널이 수신 대기 중입니다.`);
+      } else {
+        console.error('서버 주소를 가져올 수 없습니다.');
+        return;
+      }
+    } catch (error) {
+      console.error('SSH 터널링 오류:', error);
+      return;
+    }
+  }
 
   try {
-    const [server, client] = await createTunnel(
-      tunnelOptions,
-      serverOptions,
-      sshOptions,
-      forwardOptions
-    );
-
-    const address = server.address();
-    if (address && typeof address !== 'string') {
-      console.log(`SSH 터널이 수신 대기 중입니다.`);
-
-      await mongoose.connect(process.env.MONGO_URI || '');
-      console.log('MongoDB에 성공적으로 연결되었습니다.');
-    } else {
-      console.error('서버 주소를 가져올 수 없습니다.');
-    }
+    await mongoose.connect(process.env.MONGO_URI || '');
+    console.log('MongoDB에 성공적으로 연결되었습니다.');
   } catch (error) {
-    console.error('SSH 터널링 오류:', error);
+    console.error('MongoDB 연결 오류:', error);
   }
 };
 


### PR DESCRIPTION
## 🔗 Linked Issue #96

## 🙋‍ Summary (요약) 
- db연동시 로컬/배포환경 분리를 위한 로직 추가
- server docker파일 수정

## 😎 Description (변경사항)
### db연동시 로컬/배포환경 분리를 위한 로직 추가
- db연동하는 코드를 로컬환경만 고려한 코드로 작성해두었습니다.
  - ssh터널링을 이용하여 private db server에 접근해 연동하는 방식
- 배포환경에서는 바로 터널링 없이 private db 서버로 연동시도를 하면 되기에 해당 로직을 추가하였습니다.
### server docker파일 수정
- client 배포 이미지는 nginx를 이용한 배포인지라, 정적인 파일로 이루어져 있어 dist 폴더 내용들만 카피하고 배포하면 되었습니다.
- 하지만, server 배포 이미지는 정적인 파일을 배포하는 것이 아니기에 정적인 형식처럼 배포하던 스크립트를 수정하였습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
