### PR TITLE
깃허브 액션 테스트

### DIFF
--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -44,9 +44,13 @@ jobs:
           cd apps/server
           pnpm run build
 
-      - name: Build the Docker image
+      - name: Build base image
         run: |
           docker build . --file Dockerfile.base --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0 base-image
+
+      - name: Build frontend and backend images
+        run: |
           docker build . --file apps/client/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
           docker build . --file apps/server/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
 

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PASSWORD }}
+          password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd boolock/web31-BooLock

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -88,8 +88,8 @@ jobs:
             echo "MONGO_URI=\"${{ secrets.MONGO_URI }}\"" > apps/server/.env
             echo "IS_LOCAL=false" >> apps/server/.env
 
-            sudo docker-compose build base
-            sudo docker-compose pull
-            sudo docker-compose down
-            sudo docker-compose up -d
+            sudo docker compose build base
+            sudo docker compose pull
+            sudo docker compose down
+            sudo docker compose up -d
             sudo docker image prune -f

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -1,0 +1,88 @@
+name: ci/cd action
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+
+    - name: Install Pnpm
+      run: npm install -g pnpm
+
+    - name: Package install with pnpm
+      run : |
+        pnpm install:all
+
+    - name: Set BE .env
+      run: |
+        echo "MONGO_URI=${{ secrets.MONGO_URI }}" > apps/server/.env
+        echo "SSH_HOST=${{ secrets.SSH_HOST }}" > apps/server/.env
+        echo "SSH_PORT=${{ secrets.SSH_PORT }}" > apps/server/.env
+        echo "SSH_USER=${{ secrets.SSH_USER }}" > apps/server/.env
+        echo "SSH_PASSWORD=${{ secrets.SSH_PASSWORD }}" > apps/server/.env
+        echo "SSH_DATABASE_HOST=${{ secrets.SSH_DATABASE_HOST }}" > apps/server/.env
+        echo "SSH_DATABASE_PORT=${{ secrets.SSH_DATABASE_PORT }}" > apps/server/.env
+        echo "LOCAL_PORT=${{ secrets.LOCAL_PORT }}" > apps/server/.env
+        
+    - name: Buld Frontend
+      run: |
+        cd apps/client
+        pnpm run build
+
+    - name: Build Backend
+      run: |
+        cd apps/server
+        pnpm run build
+
+    - name: Build the Docker image
+      run: |
+        docker build . --file Dockerfile.base --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
+        docker build . --file apps/client/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
+        docker build . --file apps/server/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Docker Hub push
+      run: |
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
+        
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        run: sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Deploy with docker
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd boolock/web31-BooLock
+            git checkout dev
+            git pull
+            sudo docker-compose build base
+            sudo docker-compose pull
+            sudo docker-compose down
+            sudo docker-compose up -d
+            sudo docker image prune -f

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -2,67 +2,66 @@ name: ci/cd action
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: ['dev']
   pull_request:
-    branches: [ "dev" ]
+    branches: ['dev']
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.x'
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
 
-    - name: Install Pnpm
-      run: npm install -g pnpm
+      - name: Install Pnpm
+        run: npm install -g pnpm
 
-    - name: Package install with pnpm
-      run : |
-        pnpm install:all
+      - name: Package install with pnpm
+        run: pnpm install:all
 
-    - name: Set BE .env
-      run: |
-        echo "MONGO_URI=${{ secrets.MONGO_URI }}" > apps/server/.env
-        echo "SSH_HOST=${{ secrets.SSH_HOST }}" > apps/server/.env
-        echo "SSH_PORT=${{ secrets.SSH_PORT }}" > apps/server/.env
-        echo "SSH_USER=${{ secrets.SSH_USER }}" > apps/server/.env
-        echo "SSH_PASSWORD=${{ secrets.SSH_PASSWORD }}" > apps/server/.env
-        echo "SSH_DATABASE_HOST=${{ secrets.SSH_DATABASE_HOST }}" > apps/server/.env
-        echo "SSH_DATABASE_PORT=${{ secrets.SSH_DATABASE_PORT }}" > apps/server/.env
-        echo "LOCAL_PORT=${{ secrets.LOCAL_PORT }}" > apps/server/.env
-        
-    - name: Buld Frontend
-      run: |
-        cd apps/client
-        pnpm run build
+      - name: Set BE .env
+        run: |
+          printf "MONGO_URI=\"${{ secrets.MONGO_URI }}\"\n" > apps/server/.env
+          echo "SSH_HOST=${{ secrets.SSH_HOST }}" >> apps/server/.env
+          echo "SSH_PORT=${{ secrets.SSH_PORT }}" >> apps/server/.env
+          echo "SSH_USER=${{ secrets.SSH_USER }}" >> apps/server/.env
+          echo "SSH_PASSWORD=${{ secrets.SSH_PASSWORD }}" >> apps/server/.env
+          echo "SSH_DATABASE_HOST=${{ secrets.SSH_DATABASE_HOST }}" >> apps/server/.env
+          echo "SSH_DATABASE_PORT=${{ secrets.SSH_DATABASE_PORT }}" >> apps/server/.env
+          echo "LOCAL_PORT=${{ secrets.LOCAL_PORT }}" >> apps/server/.env
 
-    - name: Build Backend
-      run: |
-        cd apps/server
-        pnpm run build
+      - name: Buld Frontend
+        run: |
+          cd apps/client
+          pnpm run build
 
-    - name: Build the Docker image
-      run: |
-        docker build . --file Dockerfile.base --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
-        docker build . --file apps/client/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
-        docker build . --file apps/server/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
+      - name: Build Backend
+        run: |
+          cd apps/server
+          pnpm run build
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build the Docker image
+        run: |
+          docker build . --file Dockerfile.base --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
+          docker build . --file apps/client/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
+          docker build . --file apps/server/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
 
-    - name: Docker Hub push
-      run: |
-        docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
-        docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
-        docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
-        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Docker Hub push
+        run: |
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
+
   deploy:
     needs: build
     runs-on: ubuntu-latest
@@ -81,6 +80,10 @@ jobs:
             cd boolock/web31-BooLock
             git checkout dev
             git pull
+
+            printf "MONGO_URI=\"${{ secrets.MONGO_URI }}\"\n" > apps/server/.env
+            echo "IS_LOCAL=false" >> apps/server/.env
+
             sudo docker-compose build base
             sudo docker-compose pull
             sudo docker-compose down

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Set BE .env
         run: |
-          printf "MONGO_URI=\"${{ secrets.MONGO_URI }}\"\n" > apps/server/.env
+          echo "MONGO_URI=\"${{ secrets.MONGO_URI }}\"" > apps/server/.env
           echo "SSH_HOST=${{ secrets.SSH_HOST }}" >> apps/server/.env
           echo "SSH_PORT=${{ secrets.SSH_PORT }}" >> apps/server/.env
           echo "SSH_USER=${{ secrets.SSH_USER }}" >> apps/server/.env
@@ -81,7 +81,7 @@ jobs:
             git checkout dev
             git pull
 
-            printf "MONGO_URI=\"${{ secrets.MONGO_URI }}\"\n" > apps/server/.env
+            echo "MONGO_URI=\"${{ secrets.MONGO_URI }}\"" > apps/server/.env
             echo "IS_LOCAL=false" >> apps/server/.env
 
             sudo docker-compose build base


### PR DESCRIPTION
아니 pr 이름 만들어질 줄 알고 깃허브 액션 테스트라고 한건데 브랜치가 만들어졌네요 당황스럽네요

## 🔗 Linked Issue #52 

## 🙋‍ Summary (요약) 
- 깃허브 액션 스크립트 제작

## 😎 Description (변경사항)
### 깃허브 액션 스크립트 제작
```yml
on:
  push:
    branches: ['dev']
  pull_request:
    branches: ['dev']
```
- 이번에 만든 action 스크립트는 dev용으로만 만들었습니다. 즉, 테스트 서버에 올라가는 부분에 대한 action 스크립트를 작성한 것입니다.
- main으로 올라갈때에 대한 스크립트는 메인 서버 구축 및 배포 환경이 갖추어졌을 때 다시 제작하도록 하겠습니다.

```yml

jobs:
  build:
    ...
  deploy:
    needs: build
```
- build와 deploy로 나누어 실행됩니다.
- build는 dev 실행이 잘 되는지, docker 이미지가 잘 빌드 되는지 확인합니다.
- deploy는 build가 오류 없이 실행된 후 실행됩니다. 실제 저희 테스트 서버에 자동으로 배포해주는 역할을 합니다.


- build과정은 아래와 같이 이루어집니다.

```yml
    steps:
      - uses: actions/checkout@v4
      - name: Set up Node.js
        uses: actions/setup-node@v4
        with:
          node-version: '20.x'

      - name: Install Pnpm
        run: npm install -g pnpm

      - name: Package install with pnpm
        run: pnpm install:all

      - name: Set BE .env
        run: |
          echo "MONGO_URI=\"${{ secrets.MONGO_URI }}\"" > apps/server/.env
          ....
```
- 기초적으로 실행할 node버전, pnpm 패키지 설치와 의존성 설치가 이루어집니다.
- build과정에선 테스트 서버를 연결해두고 사용하는 것이 아니기 때문에 로컬환경에서 개발할 때와 똑같은 env 설정을 세팅해줍니다.

```yml
      - name: Build Frontend
        run: |
          cd apps/client
          pnpm run build

      - name: Build Backend
        run: |
          cd apps/server
          pnpm run build
```
- client와 server 파일 빌드가 잘 이루어지는지 확인합니다.
- 생각해보니 빌드파일이 잘 만들어지는지만 확인하면 백엔드 env 설정을 해줄 필요가 없지 않나 라는 생각이 들기도 하네요 흠 🤔🤔

```yml
      - name: Build base image
        run: |
          docker build . --file Dockerfile.base --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0 base-image

      - name: Build frontend and backend images
        run: |
          docker build . --file apps/client/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
          docker build . --file apps/server/Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0

      - name: Login to Docker Hub
        uses: docker/login-action@v2
        with:
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_PASSWORD }}

      - name: Docker Hub push
        run: |
          docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_base_test:1.0
          docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_client_test:1.0
          docker push ${{ secrets.DOCKERHUB_USERNAME }}/boolock_server_test:1.0
```
- docker 이미지를 빌드하는 과정입니다.
- 수동으로 docker 이미지를 빌드할때는 docker-compose를 이용하여 base-image먼저 빌드 하고 이후 해당 이미지를 의존해 다른 이미지들이 빌드되는 과정을 겪는데, 하나하나 이미지들을 빌드해봐야하는 해당 과정에서는 다같이 처리하면 오류가 발생해 base 이미지 먼저 빌드 한 후 나머지 이미지를 빌드합니다.

```yml
  deploy:
    needs: build
    runs-on: ubuntu-latest
    steps:
      - name: Login to Docker Hub
        run: sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}

      - name: Deploy with docker
        uses: appleboy/ssh-action@v0.1.6
        with:
          host: ${{ secrets.SSH_HOST }}
          username: ${{ secrets.SSH_USER }}
          password: ${{ secrets.SSH_PASSWORD }}
          port: ${{ secrets.SSH_PORT }}
          script: |
            cd boolock/web31-BooLock
            git checkout dev
            git pull

            echo "MONGO_URI=\"${{ secrets.MONGO_URI }}\"" > apps/server/.env
            echo "IS_LOCAL=false" >> apps/server/.env

            sudo docker-compose build base
            sudo docker-compose pull
            sudo docker-compose down
            sudo docker-compose up -d
            sudo docker image prune -f
```
- deploy같은 경우 먼저 ssh 접속한 후 실제 서버에서 실행시켜주는 스크립트를 작성했습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
