### PR TITLE
[#5] 워크스페이스 삭제 기능 구현 (PR 리뷰 반영)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,24 @@
 ## 🍀 서비스
 ![image](https://github.com/user-attachments/assets/28d77d78-d74f-4ad0-819c-a0f30479ba27)
 
-
 <br/>
 
+## 🍀 전체적 시스템 아키텍처
+![Group 1764](https://github.com/user-attachments/assets/123c2511-491a-4c77-9dc5-0da877908307)
 
-## 🍀 네부캠 방범대
+<br />
 
-| **FE** | **FE** | **FE** | **FE** | **FE** |
-| :------: |  :------: |  :------: |  :------: |  :------: |
-| **권나연** | **이영재** | **이유진** | **최경일** | **홍현지** |
-| [<img src="https://i.namu.wiki/i/qWyoh8nA_DcTuY4gqcmkFC2k5Sbn8D6yVCVRQHMhJD-eRYtugUDNg6jP-v0VqbnFdCjL4jYrepNXw9ey8ouFAA.webp" height=180 width=150> <br/> @chichoc](https://github.com/chichoc) | [<img src="https://i.namu.wiki/i/4xQD4LBkRRW5MdrFZj6vsSTZsN8kd1q_H4uXLi5D06yVH-u8NFtgCDglmR9e_8D2WFlwV8xn1-m1BWAQy_1Epw.webp" height=180 width=150> <br/> @lee0jae330](https://github.com/lee0jae330) | [<img src="https://i.namu.wiki/i/zfd-NOPP39XJ49BUBLXu8d3SAPsYnpvqYviuQHzSe8FqI6DhYAaHp5Nx30dWi_Q5XGUcbczMfuSp1lOMAN3NvA.webp" height=180 width=150> <br/> @Yujin](https://github.com/Ujaa) | [<img src="https://i.namu.wiki/i/hWLEwQhnjvdoRZQhrgHMKAZjiSVPO5D86_nBD6OCVLHamm0dM7Ssv2KTfYgjJj-V_X3hMsgV-LeIgI7lmbqzhA.webp" height=180 width=150> <br/> @inhachoi](https://github.com/inhachoi) | [<img src="https://i.namu.wiki/i/5Veq9acZq3uqIUMsQbKyf4wjHiuk500_e7LUTtdWvG_2m7Wax-Anb5bFATOMsQReegqabE05_P6Swl9h9vUl3g.webp" height=180 width=150> <br/> @Honghyeonji](https://github.com/Honghyeonji) |
+## 🛹 메인 예상 디자인
+
+![image](https://github.com/user-attachments/assets/bdf41054-7d7a-448b-ab4a-0e8a01374c5e)
+
+
+## 현재 진행 사항
+![storybook2](https://github.com/user-attachments/assets/e8abc931-673c-49a4-821b-f368f9e7b094)
+
+![BooLock-Chrome2024-11-1422-48-34-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/b5473beb-b819-4100-a805-d7159537fbd9)
+
+![BooLock-Chrome2024-11-1422-48-34-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/236a8f09-7b89-4761-8449-d36e3fc7d677)
 
 
 <br />
@@ -28,7 +36,6 @@
 ![image](https://github.com/user-attachments/assets/d94c33aa-04be-45d2-adae-00b715e901f5)
 
 
-
 <br />
 
 ## ⚒️ 기술 스택 [[Detail Link]](https://github.com/boostcampwm-2024/web31-BooLock/wiki/%EA%B8%B0%EC%88%A0%EC%8A%A4%ED%83%9D)
@@ -41,55 +48,48 @@
 |배포|![Nginx](https://img.shields.io/badge/nginx-%23009639.svg?style=for-the-badge&logo=nginx&logoColor=white) ![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white) ![Naver Cloud Platform](https://img.shields.io/badge/NAVER%20CLOUD%20PLATFORM-2DB400?style=for-the-badge)|
 |협업|![Notion](https://img.shields.io/badge/Notion-%23000000.svg?style=for-the-badge&logo=notion&logoColor=white) ![Figma](https://img.shields.io/badge/figma-%23F24E1E.svg?style=for-the-badge&logo=figma&logoColor=white)|
 
-<br />
-
-## 🧑‍🏫 구조
-
-![image](https://github.com/user-attachments/assets/11f3904e-c0f0-4cf0-a516-f69578740fe5)
-
-![image](https://github.com/user-attachments/assets/b91a3f64-4113-4207-a0b2-142a80c71b4c)
-
-![image](https://github.com/user-attachments/assets/3e90d6f3-cce6-464b-9356-79564532165c)
-
-<br />
-
-## 📈 진행 사항
-
-![image](https://github.com/user-attachments/assets/ab31430b-7f7a-4607-8e19-47b905074c61)
+<br/>
 
 
-![image](https://github.com/user-attachments/assets/53e3c214-276f-448d-be7b-5ceb4cfa094a)
+## 🍀 네부캠 방범대
 
-
-<br />
-
-## 🛹 메인 예상 디자인
-
-![image](https://github.com/user-attachments/assets/bdf41054-7d7a-448b-ab4a-0e8a01374c5e)
+| **FE** | **FE** | **FE** | **FE** | **FE** |
+| :------: |  :------: |  :------: |  :------: |  :------: |
+| **권나연** | **이영재** | **이유진** | **최경일** | **홍현지** |
+| [<img src="https://i.namu.wiki/i/qWyoh8nA_DcTuY4gqcmkFC2k5Sbn8D6yVCVRQHMhJD-eRYtugUDNg6jP-v0VqbnFdCjL4jYrepNXw9ey8ouFAA.webp" height=180 width=150> <br/> @chichoc](https://github.com/chichoc) | [<img src="https://i.namu.wiki/i/4xQD4LBkRRW5MdrFZj6vsSTZsN8kd1q_H4uXLi5D06yVH-u8NFtgCDglmR9e_8D2WFlwV8xn1-m1BWAQy_1Epw.webp" height=180 width=150> <br/> @lee0jae330](https://github.com/lee0jae330) | [<img src="https://i.namu.wiki/i/zfd-NOPP39XJ49BUBLXu8d3SAPsYnpvqYviuQHzSe8FqI6DhYAaHp5Nx30dWi_Q5XGUcbczMfuSp1lOMAN3NvA.webp" height=180 width=150> <br/> @Yujin](https://github.com/Ujaa) | [<img src="https://i.namu.wiki/i/hWLEwQhnjvdoRZQhrgHMKAZjiSVPO5D86_nBD6OCVLHamm0dM7Ssv2KTfYgjJj-V_X3hMsgV-LeIgI7lmbqzhA.webp" height=180 width=150> <br/> @inhachoi](https://github.com/inhachoi) | [<img src="https://i.namu.wiki/i/5Veq9acZq3uqIUMsQbKyf4wjHiuk500_e7LUTtdWvG_2m7Wax-Anb5bFATOMsQReegqabE05_P6Swl9h9vUl3g.webp" height=180 width=150> <br/> @Honghyeonji](https://github.com/Honghyeonji) |
 
 
 <br />
 
 ## ⭐ 팀 목표
-### v 0.0.0
-1. 코드품질: 누가 봐도 깔끔한 코드를 작성한다.
-    - 컨벤션 준수 → ESLint와 Prettier로 검증한다.
-2. 동작이 1순위이다.
-    - 조립한 블록을 통해 HTML, CSS 코드 결과를 확인할 수 있다.
-    - 블록리 라이브러리의 기능 중 몇 가지를 직접 구현한다.
-    - 사용자 중심 서비스를 구현한다. (FE 5명 다운 결과물을 만든다.)
-        - 렌더링 최적화
-        - 이미지 최적화
-        - 크로스브라우징 (크롬, 엣지)
-        - 데이터 패칭에 끊김이 없다. (로딩중, 에러화면 처리 및 패칭이 오래 걸리게 하지 않는다)
-        - 스켈레톤 UI로 경험 사용자 경험 개선
-    - 스토리 하나를 구현할 때마다 최소 1가지 테스트를 작성한다.
-3. 성공적인 배포
-    - 하나의 서비스를 완성한다. (버전 업하는 식으로 개선시키기)
-    - 서비스를 사용한 유저한테 피드백을 받아서 보완한다.
-4. 개발자적 성장
-    - 모두가 모든 코드를 이해한다. (`어? 제 파트 아닌데요` 금지)
-    - 용두사미가 되지 않는다. (저희는 개발자입니다.) (`여기까지만 하죠` 금지)
-5. WE ARE TEAM 
-    - 프로젝트가 끝나고 다 같이 🏕️ **글램핑**을 가는 사이가 된다.
-
+### v 1.0.0
+1. 코드품질
+   * ESLint 규칙 준수율 95% 이상 유지
+   * PR 리뷰 시 스타일 관련 수정 요청 3개 이하
+   * 모든 컴포넌트에 TypeScript 적용 (타입 any 사용 5% 이하)
+2. 동작 품질
+   * Performance 점수 (Chrome Lighthouse 기준)
+     - 첫 페이지 로딩 속도 2초 이내
+     - Lighthouse 성능 점수 90점 이상
+   * 최적화 지표
+     - 이미지 용량 최적화 (개별 이미지 300KB 이하)
+     - First Contentful Paint (FCP) 1.8초 이내
+     - Largest Contentful Paint (LCP) 2.5초 이내
+   * 크로스 브라우징
+     - Chrome, Edge에서 동일한 UI/UX 제공 (차이율 5% 이하)
+   * story 하나를 구현할 때마다 최소 1가지 테스트를 작성한다.
+3. 배포 및 운영
+   * 유저 100명 이상 모으기
+   * 사용자 피드백 10건 이상 반영
+   * 버그 수정 응답 시간 24시간 이내
+   * 배포 자동화로 배포 시간 10분 이내 달성
+4. 개발자 역량
+   * 매주 월, 수 기술 공유
+   * 매주 화, 목 코드 리팩토링
+   * 개인당 월 1회 이상 딥다이브 경험 공유
+모두가 모든 코드를 이해한다. (어? 제 파트 아닌데요 금지)
+용두사미가 되지 않는다. (저희는 개발자입니다.) (여기까지만 하죠 금지)
+5. WE ARE TEAM
+   * 월 1회 이상 팀 회식/문화 활동 진행
+   * 프로젝트 종료 시 1박 2일 글램핑 달성 🏕️
+  

--- a/apps/client/src/entities/home/WorkspaceItem.tsx
+++ b/apps/client/src/entities/home/WorkspaceItem.tsx
@@ -18,13 +18,13 @@ export const WorkspaceItem = ({
   lastEdited,
   onClick,
 }: WorkspaceItemProps) => {
-  const { openModal: onOpen, setModalContent, setModalAction } = useModalStore();
+  const { openModal: onOpen, setModalContent, setModalAction: handleClick } = useModalStore();
   const { mutate } = useDeleteWorkspace();
 
   const handleOnclick = () => {
     setModalContent(`${title}을(를)
       삭제하겠습니까?`);
-    setModalAction(() => {
+    handleClick(() => {
       mutate(workspaceId);
     });
     onOpen();

--- a/apps/client/src/entities/home/WorkspaceItem.tsx
+++ b/apps/client/src/entities/home/WorkspaceItem.tsx
@@ -1,19 +1,41 @@
 import TrashSVG from '@/shared/assets/trash.svg?react';
 import { formatRelativeOrAbsoluteDate } from '@/shared/utils';
 import { useModalStore } from '@/shared/store';
+import { useDeleteWorkspace } from '@/shared/hooks';
 
 type WorkspaceItemProps = {
+  workspaceId: string;
   title: string;
   thumbnail: string;
   lastEdited: string;
   onClick: () => void;
 };
 
-export const WorkspaceItem = ({ title, thumbnail, lastEdited, onClick }: WorkspaceItemProps) => {
-  const { openModal: onOpen } = useModalStore();
+export const WorkspaceItem = ({
+  workspaceId,
+  title,
+  thumbnail,
+  lastEdited,
+  onClick,
+}: WorkspaceItemProps) => {
+  const { openModal: onOpen, setModalContent, setModalAction } = useModalStore();
+  const { mutate } = useDeleteWorkspace();
+
+  const handleOnclick = () => {
+    setModalContent(`${title}을(를)
+      삭제하겠습니까?`);
+    setModalAction(() => {
+      mutate(workspaceId);
+    });
+    onOpen();
+  };
+
   return (
     <li className="shadow-drop relative rounded-lg">
-      <button className="absolute right-2 top-2 text-gray-300 hover:text-red-500" onClick={onOpen}>
+      <button
+        className="absolute right-2 top-2 text-gray-300 hover:text-red-500"
+        onClick={handleOnclick}
+      >
         <TrashSVG width={16} />
       </button>
       <div className="cursor-pointer" onClick={onClick}>

--- a/apps/client/src/entities/workspace/WorkspaceNameInput.tsx
+++ b/apps/client/src/entities/workspace/WorkspaceNameInput.tsx
@@ -1,9 +1,9 @@
 import { FocusEventHandler, KeyboardEventHandler } from 'react';
 
-import Spinner from '@/shared/assets/spinner.svg?react';
 import { useParams } from 'react-router-dom';
 import { useUpdateWorkspaceName } from '@/shared/hooks';
 import { useWorkspaceStore } from '@/shared/store';
+import { Spinner } from '@/shared/ui';
 
 export const WorkspaceNameInput = () => {
   const { workspaceId } = useParams() as { workspaceId: string };
@@ -46,7 +46,9 @@ export const WorkspaceNameInput = () => {
           disabled={isPending}
         />
         {isPending && (
-          <Spinner className="absolute right-5 inline h-4 w-4 animate-spin fill-green-500 text-gray-200" />
+          <div className="absolute right-5">
+            <Spinner width={4} height={4} foregroundColor="green-500" backgroundColor="gray-200" />
+          </div>
         )}
       </div>
     </>

--- a/apps/client/src/shared/api/workspaceApi.ts
+++ b/apps/client/src/shared/api/workspaceApi.ts
@@ -60,10 +60,21 @@ export const WorkspaceApi = () => {
     throw new Error('Invalid response from server');
   };
 
+  const deleteWorkspace = async (userId: string, workspaceId: string): Promise<void> => {
+    const response = await Instance.delete(`/workspace?workspaceId=${workspaceId}`, {
+      headers: { 'user-id': userId },
+    });
+
+    if (!response) {
+      throw new Error('Invalid response from server');
+    }
+  };
+
   return {
     createWorkspace,
     getWorkspaceList,
     getWorkspace,
     updateWorkspaceName,
+    deleteWorkspace,
   };
 };

--- a/apps/client/src/shared/hooks/index.ts
+++ b/apps/client/src/shared/hooks/index.ts
@@ -2,3 +2,4 @@ export { useCreateWorkspace } from './queries/useCreateWorkspace';
 export { useGetWorkspaceList } from './queries/useGetWorkspaceList';
 export { useGetWorkspace } from './queries/useGetWorkspace';
 export { useUpdateWorkspaceName } from './queries/useUpdateWorkspaceName';
+export { useDeleteWorkspace } from './queries/useDeleteWorkspace';

--- a/apps/client/src/shared/hooks/queries/useDeleteWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useDeleteWorkspace.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { WorkspaceApi } from '@/shared/api';
+import { getUserId } from '@/shared/utils';
+import toast from 'react-hot-toast';
+import { useModalStore } from '@/shared/store';
+
+export const useDeleteWorkspace = () => {
+  const queryClient = useQueryClient();
+  const workspaceApi = WorkspaceApi();
+  const userId = getUserId();
+  const { closeModal, setIsLoading } = useModalStore();
+
+  const { mutate } = useMutation({
+    mutationFn: (workspaceId: string) => {
+      setIsLoading(true);
+      return workspaceApi.deleteWorkspace(userId, workspaceId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getWorkspaceList'] });
+      toast.success('워크스페이스 삭제 성공');
+    },
+    onError: () => {
+      toast.error('워크스페이스 삭제 실패');
+    },
+    onSettled: () => {
+      setIsLoading(false);
+      closeModal();
+    },
+  });
+
+  return { mutate };
+};

--- a/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
 import { WorkspaceApi } from '@/shared/api';
 import { getUserId } from '@/shared/utils';
 import toast from 'react-hot-toast';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useWorkspaceStore } from '@/shared/store';
 
@@ -12,6 +12,7 @@ export const useGetWorkspace = (workspaceId: string) => {
   const { data, isPending, isError } = useQuery({
     queryKey: ['getWorkspace', workspaceId],
     queryFn: () => {
+      setName('워크스페이스 이름');
       return workspaceApi.getWorkspace(userId, workspaceId);
     },
   });

--- a/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
+++ b/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
@@ -18,11 +18,6 @@ export const useUpdateWorkspaceName = () => {
     onSuccess: (data) => {
       toast.success('워크스페이스 이름이 변경되었습니다.');
       setName(data?.name!);
-      queryClient.setQueryData(['getWorkspace', data.workspace_id], (oldData: any) => {
-        return {
-          workspaceDto: { ...oldData.workspaceDto, name: data.name },
-        };
-      });
       queryClient.invalidateQueries({ queryKey: ['getWorkspaceList'] });
     },
     onError: () => {

--- a/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
+++ b/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
@@ -1,10 +1,12 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { WorkspaceApi } from '@/shared/api';
 import { getUserId } from '@/shared/utils';
 import toast from 'react-hot-toast';
-import { useMutation } from '@tanstack/react-query';
 import { useWorkspaceStore } from '@/shared/store';
 
 export const useUpdateWorkspaceName = () => {
+  const queryClient = useQueryClient();
   const workspaceApi = WorkspaceApi();
   const userId = getUserId();
   const { setName } = useWorkspaceStore();
@@ -16,6 +18,12 @@ export const useUpdateWorkspaceName = () => {
     onSuccess: (data) => {
       toast.success('워크스페이스 이름이 변경되었습니다.');
       setName(data?.name!);
+      queryClient.setQueryData(['getWorkspace', data.workspace_id], (oldData: any) => {
+        return {
+          workspaceDto: { ...oldData.workspaceDto, name: data.name },
+        };
+      });
+      queryClient.invalidateQueries({ queryKey: ['getWorkspaceList'] });
     },
     onError: () => {
       toast.error('워크스페이스 이름 변경을 실패했습니다.');

--- a/apps/client/src/shared/store/useModalStore.ts
+++ b/apps/client/src/shared/store/useModalStore.ts
@@ -2,12 +2,24 @@ import { create } from 'zustand';
 
 type ModalStoreType = {
   isModalOpen: boolean;
+  modalContent: string;
+  isLoading: boolean;
+  modalAction: () => void;
   openModal: () => void;
   closeModal: () => void;
+  setModalContent: (content: string) => void;
+  setModalAction: (action: () => void) => void;
+  setIsLoading: (loading: boolean) => void;
 };
 
 export const useModalStore = create<ModalStoreType>()((set) => ({
+  modalContent: '워크스페이스 이름',
+  modalAction: () => {},
   isModalOpen: false,
+  isLoading: false,
   openModal: () => set({ isModalOpen: true }),
   closeModal: () => set({ isModalOpen: false }),
+  setModalContent: (content) => set({ modalContent: content }),
+  setModalAction: (action) => set({ modalAction: action }),
+  setIsLoading: (loading) => set({ isLoading: loading }),
 }));

--- a/apps/client/src/shared/ui/button/SquareButton.tsx
+++ b/apps/client/src/shared/ui/button/SquareButton.tsx
@@ -1,5 +1,7 @@
+import { ReactNode } from 'react';
+
 type SquareButtonProps = {
-  children: string;
+  children: ReactNode;
   variant?: 'neutral' | 'danger';
   onClick: () => void;
   isDisabled?: boolean;
@@ -9,7 +11,7 @@ export const SquareButton = ({
   children,
   variant = 'neutral',
   onClick,
-  isDisabled,
+  isDisabled = false,
 }: SquareButtonProps) => {
   const colorClasses =
     variant === 'danger'
@@ -18,8 +20,8 @@ export const SquareButton = ({
   return (
     <button
       onClick={onClick}
-      className={`text-bold-md rounded-lg px-[72px] py-4 ${colorClasses}`}
-      disabled={isDisabled && true}
+      className={`text-bold-md rounded-lg px-[72px] py-4 ${colorClasses} w-[200px]`}
+      disabled={isDisabled}
     >
       {children}
     </button>

--- a/apps/client/src/shared/ui/button/SquareButton.tsx
+++ b/apps/client/src/shared/ui/button/SquareButton.tsx
@@ -2,16 +2,25 @@ type SquareButtonProps = {
   children: string;
   variant?: 'neutral' | 'danger';
   onClick: () => void;
+  isDisabled?: boolean;
 };
 
-export const SquareButton = ({ children, variant = 'neutral', onClick }: SquareButtonProps) => {
+export const SquareButton = ({
+  children,
+  variant = 'neutral',
+  onClick,
+  isDisabled,
+}: SquareButtonProps) => {
   const colorClasses =
     variant === 'danger'
       ? 'bg-red-500 hover:bg-red-600 text-white'
       : 'bg-gray-50 hover:bg-gray-100 text-gray-300';
-
   return (
-    <button onClick={onClick} className={`text-bold-md rounded-lg px-[72px] py-4 ${colorClasses}`}>
+    <button
+      onClick={onClick}
+      className={`text-bold-md rounded-lg px-[72px] py-4 ${colorClasses}`}
+      disabled={isDisabled && true}
+    >
       {children}
     </button>
   );

--- a/apps/client/src/shared/ui/index.ts
+++ b/apps/client/src/shared/ui/index.ts
@@ -8,6 +8,7 @@ export { ModalConfirm } from './modal/ModalConfirm';
 export { ToasterWithMax } from './toast/ToasterWithMax';
 
 export { Loading } from './loading/Loading';
+export { Spinner } from './loading/Spinner';
 
 export { SkeletonWorkspace } from './skeleton/SkeletonWorkspace';
 export { SkeletonWorkspaceList } from './skeleton/SkeletonWorkspaceList';

--- a/apps/client/src/shared/ui/loading/Loading.tsx
+++ b/apps/client/src/shared/ui/loading/Loading.tsx
@@ -2,7 +2,7 @@ import { BarLoader } from 'react-spinners';
 
 export const Loading = () => {
   return (
-    <div className="fixed z-50 flex h-full w-full items-center justify-center bg-black opacity-70">
+    <div className="fixed z-[99999] flex h-full w-full items-center justify-center bg-black opacity-70">
       <BarLoader height={10} width={120} color="#02D085" />
     </div>
   );

--- a/apps/client/src/shared/ui/loading/Spinner.tsx
+++ b/apps/client/src/shared/ui/loading/Spinner.tsx
@@ -1,0 +1,28 @@
+import SpinIcon from '@/shared/assets/spinner.svg?react';
+
+type SpinnerProps = {
+  width: number;
+  height: number;
+  foregroundColor: string;
+  backgroundColor: string;
+};
+
+/**
+ * @description
+ * 스피너 컴포넌트
+ * width, height에 들어가는 값은 tailwind css에 정의된 값만 들어갈 수 있습니다.
+ * @param {string} width
+ * @param {string} height
+ * @param {string} foregroundColor
+ * @param {string} backgroundColor
+ *
+ * @returns
+ */
+export const Spinner = ({ width, height, foregroundColor, backgroundColor }: SpinnerProps) => {
+  const w = `w-${width}`;
+  const h = `h-${height}`;
+  const foreground = `fill-${foregroundColor}`;
+  const background = `text-${backgroundColor}`;
+
+  return <SpinIcon className={`inline ${h} ${w} animate-spin ${foreground} ${background}`} />;
+};

--- a/apps/client/src/widgets/home/WorkspaceContainer.tsx
+++ b/apps/client/src/widgets/home/WorkspaceContainer.tsx
@@ -17,7 +17,6 @@ export const WorkspaceContainer = () => {
       rootMargin: '0px',
       threshold: 0.5,
     };
-
     const fetchCallback: IntersectionObserverCallback = (entries, observer) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting && hasNextPage) {
@@ -26,13 +25,10 @@ export const WorkspaceContainer = () => {
         }
       });
     };
-
     const observer = new IntersectionObserver(fetchCallback, options);
-
     if (nextFetchTargetRef.current) {
       observer.observe(nextFetchTargetRef.current);
     }
-
     return () => {
       if (nextFetchTargetRef.current) {
         observer.unobserve(nextFetchTargetRef.current);

--- a/apps/client/src/widgets/home/WorkspaceList.tsx
+++ b/apps/client/src/widgets/home/WorkspaceList.tsx
@@ -13,6 +13,7 @@ export const WorkspaceList = ({ workspaceList }: workspaceListProps) => {
       {workspaceList.map((workspace) => (
         <WorkspaceItem
           key={workspace.workspace_id}
+          workspaceId={workspace.workspace_id}
           title={workspace.name}
           thumbnail={workspace.thumbnail || ''}
           lastEdited={workspace.updated_at}

--- a/apps/client/src/widgets/home/WorkspaceModal.tsx
+++ b/apps/client/src/widgets/home/WorkspaceModal.tsx
@@ -1,4 +1,4 @@
-import { ModalConfirm, SquareButton } from '@/shared/ui';
+import { ModalConfirm, Spinner, SquareButton } from '@/shared/ui';
 
 import { useModalStore } from '@/shared/store/useModalStore';
 
@@ -41,7 +41,18 @@ export const WorkspaceModal = () => {
               variant={content.type}
               isDisabled={content.isDisabled}
             >
-              {content.name}
+              <>
+                {content.isDisabled ? (
+                  <Spinner
+                    width={4}
+                    height={4}
+                    foregroundColor="gray-white"
+                    backgroundColor="gray-200"
+                  />
+                ) : (
+                  content.name
+                )}
+              </>
             </SquareButton>
           ))}
         </div>

--- a/apps/client/src/widgets/home/WorkspaceModal.tsx
+++ b/apps/client/src/widgets/home/WorkspaceModal.tsx
@@ -2,27 +2,25 @@ import { ModalConfirm, SquareButton } from '@/shared/ui';
 
 import { useModalStore } from '@/shared/store/useModalStore';
 
-type WorkspaceModalProps = {
-  workspaceName?: string;
-};
-
 type TbuttonContent = {
   name: string;
   func: () => void;
   type: 'neutral' | 'danger';
+  isDisabled?: boolean;
 };
 
-export const WorkspaceModal = ({ workspaceName = '[워크스페이스 이름]' }: WorkspaceModalProps) => {
-  const { isModalOpen: isOpen, closeModal: onClose } = useModalStore();
-
-  const removeWorkspace = () => {
-    // TODO: 워크스페이스 삭제
-    onClose();
-  };
+export const WorkspaceModal = () => {
+  const {
+    isModalOpen: isOpen,
+    closeModal: onClose,
+    modalContent,
+    modalAction,
+    isLoading,
+  } = useModalStore();
 
   const buttonContents: TbuttonContent[] = [
     { name: '아차차~', func: onClose, type: 'neutral' },
-    { name: '지울래요', func: removeWorkspace, type: 'danger' },
+    { name: '지울래요', func: modalAction, type: 'danger', isDisabled: isLoading },
   ];
 
   return (
@@ -31,14 +29,18 @@ export const WorkspaceModal = ({ workspaceName = '[워크스페이스 이름]' }
         <div className="mb-10 flex flex-col items-center justify-center gap-3 text-center">
           <img src="./images/booduck_modal.png" width={100} height={100} />
           <p className="text-semibold-lg whitespace-pre-line leading-tight text-gray-500">
-            {`${workspaceName}을 
-            삭제하시겠습니까?`}
+            {modalContent}
           </p>
         </div>
 
         <div className="flex gap-3">
           {buttonContents.map((content, index) => (
-            <SquareButton key={index} onClick={() => content.func()} variant={content.type}>
+            <SquareButton
+              key={index}
+              onClick={() => content.func()}
+              variant={content.type}
+              isDisabled={content.isDisabled}
+            >
               {content.name}
             </SquareButton>
           ))}

--- a/apps/server/src/controllers/workspaceController.ts
+++ b/apps/server/src/controllers/workspaceController.ts
@@ -94,5 +94,32 @@ export const WorkspaceController = () => {
       }
     }
   };
-  return { createNewWorkspace, getWorkspaceListByPage, getWorkspaceInfo, editWorkspaceName };
+
+  const removeWorkspace = async (req: Request, res: Response) => {
+    try {
+      const userId = req.get('user-id') as string;
+      const workspaceId = req.query.workspaceId as string;
+      const deletedWorkspace = await workspaceService.deleteWorkspace(userId, workspaceId);
+      if (!deletedWorkspace) {
+        throw new Error('Workspace not found');
+      }
+      return res.status(200).json({ message: 'success' });
+    } catch (error) {
+      console.error(error);
+      if (error instanceof Error) {
+        if (error.message === 'Workspace not found') {
+          return res.status(404).json({ message: ERROR_MESSAGE[404] });
+        }
+        res.status(500).json({ message: ERROR_MESSAGE[500] });
+      }
+    }
+  };
+
+  return {
+    createNewWorkspace,
+    getWorkspaceListByPage,
+    getWorkspaceInfo,
+    editWorkspaceName,
+    removeWorkspace,
+  };
 };

--- a/apps/server/src/routes/v1/workspaceRoute.ts
+++ b/apps/server/src/routes/v1/workspaceRoute.ts
@@ -157,3 +157,34 @@ workspaceRouter.patch(
   */
   workspaceController.editWorkspaceName
 );
+
+workspaceRouter.delete(
+  '/',
+  /* 
+    #swagger.summary = '워크스페이스 삭제'
+    #swagger.description = 'user id 와 workspace id로 워크스페이스를 조회 후 삭제합니다.'
+    #swagger.tags = ['Workspace']
+    #swagger.parameters['user-id'] = {
+      in: 'header',
+      description: '유저 아이디 (UUID 형식)',
+      type: 'string',
+      required: true,
+    }
+    #swagger.parameters['workspaceId'] = {
+      in: 'query',
+      description: '워크스페이스 아이디 (UUID 형식)',
+      type: 'string',
+      required: true,
+    }
+    #swagger.responses[200] = {
+      description: 'success',
+    }
+    #swagger.responses[404] = {
+      description: 'Not Found'
+    }
+    #swagger.responses[500] = {
+      description: 'internal server error'
+    }
+  */
+  workspaceController.removeWorkspace
+);

--- a/apps/server/src/services/workspaceService.ts
+++ b/apps/server/src/services/workspaceService.ts
@@ -93,9 +93,9 @@ export const WorkspaceService = () => {
       return updatedWorkspace;
     } catch (error) {
       if (error instanceof Error) {
-        throw new Error(`Failed to get workspace : ${error.message}`);
+        throw new Error(`Failed to update workspace : ${error.message}`);
       }
-      throw new Error(`Unknown Error ocurred while getting workspace`);
+      throw new Error(`Unknown Error ocurred while udating workspace`);
     }
   };
 
@@ -108,9 +108,9 @@ export const WorkspaceService = () => {
       return deletedWorkspace;
     } catch (error) {
       if (error instanceof Error) {
-        throw new Error(`Failed to get workspace : ${error.message}`);
+        throw new Error(`Failed to delete workspace : ${error.message}`);
       }
-      throw new Error(`Unknown Error ocurred while getting workspace`);
+      throw new Error(`Unknown Error ocurred while deleting workspace`);
     }
   };
 

--- a/apps/server/src/services/workspaceService.ts
+++ b/apps/server/src/services/workspaceService.ts
@@ -30,7 +30,12 @@ export const WorkspaceService = () => {
     cursor: { updatedAt: string; workspaceId: string } | null
   ) => {
     try {
-      const query: any = { user_id: userId };
+      const query: {
+        user_id: string;
+        $or?: Array<
+          { updated_at: { $lt: string } } | { updated_at: string; workspace_id: { $gt: string } }
+        >;
+      } = { user_id: userId };
       if (cursor) {
         query.$or = [
           { updated_at: { $lt: cursor.updatedAt } },
@@ -94,10 +99,26 @@ export const WorkspaceService = () => {
     }
   };
 
+  const deleteWorkspace = async (userId: string, workspaceId: string) => {
+    try {
+      const deletedWorkspace = await Workspace.findOneAndDelete({
+        user_id: userId,
+        workspace_id: workspaceId,
+      }).exec();
+      return deletedWorkspace;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get workspace : ${error.message}`);
+      }
+      throw new Error(`Unknown Error ocurred while getting workspace`);
+    }
+  };
+
   return {
     createWorkspace,
     findWorkspaceListByPage,
     findWorkspaceByWorkspaceId,
     updateWorkspaceName,
+    deleteWorkspace,
   };
 };


### PR DESCRIPTION
## 🔗 #5 

## 🙋‍ Summary (요약) 
- 워크스페이스 삭제 기능 구현

## 😎 Description (변경사항)
### 워크스페이스 삭제 API 구현
- API 명세
  - method : DELETE , end-point : "/workspace
  - headers : { user-id : 유저 아이디 }
  - query : ?workspaceId=워크스페이스 아이디
  - workspace가 존재하지 않으면 : 404 에러
  - 그외 에러 : 500 에러
- Swagger 명세 작성

### 워크스페이스 삭제 API 연동
- Trashcan Icon 클릭 시 modal Content 및 modal Action을 등록
```ts
  const handleOnclick = () => {
    setModalContent(`${title}을(를)
      삭제하겠습니까?`);
    setModalAction(() => {
      mutate(workspaceId);
    });
    onOpen();
  };
```
- 워크스페이스 삭제 요청 시 모달의 `isLoading`을 `true`로 바꾸어 모달의 삭제 버튼이 여러번 클릭되어 api가 여러 번 요청 되는 현상을 방지했습니다.
- 워크스페이스 삭제 성공 시 getWorkspaceList의 캐시 데이터를 refetch하도록 했습니다.
```tsx
   onSuccess: () => {
      queryClient.invalidateQueries({ queryKey: ['getWorkspaceList'] });
      toast.success('워크스페이스 삭제 성공');
    },

```
![BooLock-Chrome2024-11-1500-32-08-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/02de38f7-43b3-4e5e-a74e-b20f8e68fc5a)

### 추가 변경 사항

- 모달 삭제 버튼 클릭 시 삭제 요청 대기 시간동안 로딩위젯이 나오도록 변경했습니다.

![BooLock-Chrome2024-11-1617-12-41-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/feeed108-60d7-4115-a0e1-767c83d8b403)

- PR 리뷰 반영
  -  모달의 `isLoading`은 아직 변경하지 않은 상태입니다.
  - 불필요한 코드 삭제

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
- 모달 쪽 구현하면서 어쩔 수 없이 전역 상태를 많이 썼는데 이 부분에 대해 어떻게 생각하시는 지 의견이 궁금합니다..!
