### PR TITLE
[#32]  'html', 'head', 'body' 블록 캔버스에 고정시키기

### DIFF
--- a/apps/client/src/shared/types/blockType.ts
+++ b/apps/client/src/shared/types/blockType.ts
@@ -1,0 +1,10 @@
+export type TBlockInfo = {
+  kind: string;
+  type: string;
+  description: string;
+};
+
+export type TBlockContents = Record<
+  'container' | 'text' | 'form' | 'table' | 'list' | 'link' | 'etc',
+  TBlockInfo[]
+>;

--- a/apps/client/src/shared/types/index.ts
+++ b/apps/client/src/shared/types/index.ts
@@ -9,7 +9,7 @@ export type {
 } from './workspaceType';
 
 export type { TcssCategory, TcssCategoryItem, TcssCategoryList } from './cssCategoryType';
-
+export type { TBlockInfo, TBlockContents } from './blockType';
 export type { IExtendedIToolbox } from './extendedType';
 export type { TTabConfig, TTabsConfig, TTabToolboxConfig } from './tabType';
 export type { Tblock, TtoolboxConfig } from './styleToolboxType';

--- a/apps/client/src/shared/utils/boolockConstants.ts
+++ b/apps/client/src/shared/utils/boolockConstants.ts
@@ -9,4 +9,11 @@ export const addPreviousTypeName = (type: string) => {
   return `${PREVIOUS_TYPE_NAME}${type}`;
 };
 
+export const removePreviousTypeName = (type: string): string => {
+  if (type.startsWith(PREVIOUS_TYPE_NAME)) {
+    return type.slice(PREVIOUS_TYPE_NAME.length);
+  }
+  return type;
+};
+
 // TODO: css 클래스명 만들때 해당 previousTypeName으로 시작할 경우 블록 생성이 안 되도록 막는 로직도 추가해주시길 바랍니다.

--- a/apps/client/src/shared/utils/index.ts
+++ b/apps/client/src/shared/utils/index.ts
@@ -2,6 +2,10 @@ export { CATEGORY_ICONS } from './categoryIcons';
 export { getUserId } from './userId';
 export { formatRelativeOrAbsoluteDate } from './dateFormat';
 export { w, h, foreground, background } from './spinnerStyle';
-export { addPreviousTypeName, PREVIOUS_TYPE_NAME } from './boolockConstants';
+export {
+  addPreviousTypeName,
+  removePreviousTypeName,
+  PREVIOUS_TYPE_NAME,
+} from './boolockConstants';
 export { debounce } from './debounce';
 export { cssCategoryList } from './cssCategoryList';

--- a/apps/client/src/widgets/index.ts
+++ b/apps/client/src/widgets/index.ts
@@ -18,7 +18,7 @@ export { cssCodeGenerator } from './workspace/css/cssCodeGenerator';
 
 export { categoryColours } from './workspace/blockly/categoryColours';
 export { defineBlocks } from './workspace/blockly/defineBlocks';
-export { htmlBlockContents } from './workspace/blockly/htmlBlockContents';
+export { blockContents } from './workspace/blockly/htmlBlockContents';
 export { initTheme } from './workspace/blockly/initTheme';
 export { htmlTagToolboxConfig } from './workspace/blockly/htmlTagToolboxConfig';
 export { cssStyleToolboxConfig } from './workspace/blockly/cssStyleToolboxConfig';

--- a/apps/client/src/widgets/workspace/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent.tsx
@@ -20,6 +20,7 @@ import { registerCustomComponents } from '@/core/register';
 import { tabToolboxConfig } from './blockly/tabConfig';
 import { defineBlocks } from './blockly/defineBlocks';
 import { blockContents } from './blockly/htmlBlockContents';
+import { initializeBlocks } from './blockly/initBlocks';
 
 registerCustomComponents();
 defineBlocks(blockContents);
@@ -51,6 +52,8 @@ export const WorkspaceContent = () => {
     });
 
     (newWorkspace.getToolbox() as TabbedToolbox).setConfig(tabToolboxConfig);
+
+    initializeBlocks(newWorkspace);
 
     // workspace 변화 감지해 자동 변환
     const handleAutoConversion = (event: Blockly.Events.Abstract) => {

--- a/apps/client/src/widgets/workspace/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent.tsx
@@ -19,9 +19,10 @@ import TabbedToolbox from '@/core/tabbedToolbox';
 import { registerCustomComponents } from '@/core/register';
 import { tabToolboxConfig } from './blockly/tabConfig';
 import { defineBlocks } from './blockly/defineBlocks';
+import { blockContents } from './blockly/htmlBlockContents';
 
 registerCustomComponents();
-defineBlocks();
+defineBlocks(blockContents);
 
 export const WorkspaceContent = () => {
   const [htmlCode, setHtmlCode] = useState<string>('');

--- a/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
+++ b/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
@@ -1,6 +1,7 @@
 import { CustomFieldLabelSerializable } from '@/core/customFieldLabelSerializable';
 import { CustomFieldTextInput } from '@/core/customFieldTextInput';
-import { addPreviousTypeName } from '@/shared/utils';
+import { TBlockContents } from '@/shared/types';
+import { removePreviousTypeName } from '@/shared/utils';
 import * as Blockly from 'blockly/core';
 
 /**
@@ -27,15 +28,17 @@ const defineBlockWithDefaults = (
     if (isDefault) {
       this.setPreviousStatement(true);
       this.setNextStatement(true);
-      this.appendValueInput('css class').setCheck('CSS-CLASS').appendField(blockName);
+      this.appendValueInput('css class')
+        .setCheck('CSS-CLASS')
+        .appendField(removePreviousTypeName(blockName));
       this.appendStatementInput('children').appendField();
     }
   };
 
-  Blockly.Blocks[addPreviousTypeName(blockName)] = blockDefinition;
+  Blockly.Blocks[blockName] = blockDefinition;
 };
 
-export const defineBlocks = () => {
+export const defineBlocks = (blockContents: TBlockContents) => {
   defineBlockWithDefaults(
     'html',
     1,
@@ -63,22 +66,34 @@ export const defineBlocks = () => {
 
   defineBlockWithDefaults('body', 3);
 
-  defineBlockWithDefaults('p', 1);
-
-  defineBlockWithDefaults('button', 2);
-
-  defineBlockWithDefaults(
-    'text',
-    3,
-    {
-      init: function () {
-        this.setPreviousStatement(true); // 다른 블록 위에 연결 가능
-        this.setNextStatement(true); // 다른 블록 아래에 연결 가능
-        this.appendDummyInput().appendField('text').appendField(new CustomFieldTextInput(), 'TEXT');
-      },
-    },
-    false
-  );
+  //   {
+  //   kind: 'block',
+  //   type: 'span',
+  //   description: '설명 작성',
+  // },
+  Object.values(blockContents).forEach((blockInfoList) => {
+    blockInfoList.forEach((blockInfo, index) => {
+      console.log(blockInfo.type, (index % 3) + 1);
+      if (blockInfo.type === ' text') {
+        defineBlockWithDefaults(
+          'text',
+          3,
+          {
+            init: function () {
+              this.setPreviousStatement(true); // 다른 블록 위에 연결 가능
+              this.setNextStatement(true); // 다른 블록 아래에 연결 가능
+              this.appendDummyInput()
+                .appendField('text')
+                .appendField(new CustomFieldTextInput(), 'TEXT');
+            },
+          },
+          false
+        );
+      } else {
+        defineBlockWithDefaults(blockInfo.type, (index % 3) + 1);
+      }
+    });
+  });
 
   defineBlockWithDefaults(
     'css_style',

--- a/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
+++ b/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
@@ -1,7 +1,7 @@
 import { CustomFieldLabelSerializable } from '@/core/customFieldLabelSerializable';
 import { CustomFieldTextInput } from '@/core/customFieldTextInput';
 import { TBlockContents } from '@/shared/types';
-import { removePreviousTypeName } from '@/shared/utils';
+import { addPreviousTypeName, removePreviousTypeName } from '@/shared/utils';
 import * as Blockly from 'blockly/core';
 
 /**
@@ -73,17 +73,16 @@ export const defineBlocks = (blockContents: TBlockContents) => {
   // },
   Object.values(blockContents).forEach((blockInfoList) => {
     blockInfoList.forEach((blockInfo, index) => {
-      console.log(blockInfo.type, (index % 3) + 1);
-      if (blockInfo.type === ' text') {
+      if (blockInfo.type === addPreviousTypeName('text')) {
         defineBlockWithDefaults(
-          'text',
-          3,
+          blockInfo.type,
+          (index % 3) + 1,
           {
             init: function () {
               this.setPreviousStatement(true); // 다른 블록 위에 연결 가능
               this.setNextStatement(true); // 다른 블록 아래에 연결 가능
               this.appendDummyInput()
-                .appendField('text')
+                .appendField(removePreviousTypeName(blockInfo.type))
                 .appendField(new CustomFieldTextInput(), 'TEXT');
             },
           },

--- a/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
+++ b/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
@@ -40,7 +40,7 @@ const defineBlockWithDefaults = (
 
 export const defineBlocks = (blockContents: TBlockContents) => {
   defineBlockWithDefaults(
-    'html',
+    addPreviousTypeName('html'),
     1,
     {
       init: function () {
@@ -52,7 +52,7 @@ export const defineBlocks = (blockContents: TBlockContents) => {
   );
 
   defineBlockWithDefaults(
-    'head',
+    addPreviousTypeName('head'),
     2,
     {
       init: function () {
@@ -64,7 +64,7 @@ export const defineBlocks = (blockContents: TBlockContents) => {
     false
   );
 
-  defineBlockWithDefaults('body', 3);
+  defineBlockWithDefaults(addPreviousTypeName('body'), 3);
 
   //   {
   //   kind: 'block',

--- a/apps/client/src/widgets/workspace/blockly/htmlBlockContents.ts
+++ b/apps/client/src/widgets/workspace/blockly/htmlBlockContents.ts
@@ -1,28 +1,238 @@
+import { TBlockContents, TBlockInfo } from '@/shared/types';
 import { addPreviousTypeName } from '@/shared/utils';
 
-export const htmlBlockContents = [
+const containerBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
-    type: addPreviousTypeName('html'),
+    type: addPreviousTypeName('div'),
+    description: '설명 작성',
   },
   {
     kind: 'block',
-    type: addPreviousTypeName('head'),
+    type: addPreviousTypeName('span'),
+    description: '설명 작성',
   },
   {
     kind: 'block',
-    type: addPreviousTypeName('body'),
+    type: addPreviousTypeName('header'),
+    description: '설명 작성',
   },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('section'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('nav'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('main'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('article'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('footer'),
+    description: '설명 작성',
+  },
+];
+
+const textBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('p'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('strong'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('h1'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('h2'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('h3'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('h4'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('h5'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('h6'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('small'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('br'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('em'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('i'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('blockquote'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('hr'),
+    description: '설명 작성',
+  },
+];
+
+const formBlockContents: TBlockInfo[] = [
+  {
+    kind: 'block',
+    type: addPreviousTypeName('input'),
+    description: '설명 작성',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('button'),
+    description: '설명 작성',
   },
   {
     kind: 'block',
-    type: addPreviousTypeName('text'),
+    type: addPreviousTypeName('form'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('option'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('textarea'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('select'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('fieldset'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('legend'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('label'),
+    description: '설명 작성',
   },
 ];
+
+const tableBlockContents: TBlockInfo[] = [
+  {
+    kind: 'block',
+    type: addPreviousTypeName('td'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('tr'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('th'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('caption'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('table'),
+    description: '설명 작성',
+  },
+];
+
+const listBlockContents: TBlockInfo[] = [
+  {
+    kind: 'block',
+    type: addPreviousTypeName('ul'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('ol'),
+    description: '설명 작성',
+  },
+  {
+    kind: 'block',
+    type: addPreviousTypeName('li'),
+    description: '설명 작성',
+  },
+];
+
+const linkBlockContents: TBlockInfo[] = [
+  {
+    kind: 'block',
+    type: addPreviousTypeName('a'),
+    description: '설명 작성',
+  },
+];
+
+const etcBlockContents: TBlockInfo[] = [
+  {
+    kind: 'block',
+    type: addPreviousTypeName('text'),
+    description: '설명 작성',
+  },
+];
+
+export const blockContents: TBlockContents = {
+  container: containerBlockContents,
+  text: textBlockContents,
+  form: formBlockContents,
+  table: tableBlockContents,
+  list: listBlockContents,
+  link: linkBlockContents,
+  etc: etcBlockContents,
+};

--- a/apps/client/src/widgets/workspace/blockly/htmlCodeGenerator.ts
+++ b/apps/client/src/widgets/workspace/blockly/htmlCodeGenerator.ts
@@ -53,12 +53,14 @@ htmlCodeGenerator.scrub_ = function (block, code, thisOnly) {
   return code;
 };
 
-transferTagBlockToCode('html');
-transferTagBlockToCode('body');
+transferTagBlockToCode(addPreviousTypeName('html'));
+transferTagBlockToCode(addPreviousTypeName('body'));
 
 Object.values(blockContents).forEach((blockInfoList) => {
   blockInfoList.forEach((blockInfo) => {
-    transferTagBlockToCode(blockInfo.type);
+    if (blockInfo.type !== addPreviousTypeName('text')) {
+      transferTagBlockToCode(blockInfo.type);
+    }
   });
 });
 

--- a/apps/client/src/widgets/workspace/blockly/htmlCodeGenerator.ts
+++ b/apps/client/src/widgets/workspace/blockly/htmlCodeGenerator.ts
@@ -1,5 +1,6 @@
-import { addPreviousTypeName } from '@/shared/utils';
+import { addPreviousTypeName, removePreviousTypeName } from '@/shared/utils';
 import * as Blockly from 'blockly/core';
+import { blockContents } from './htmlBlockContents';
 
 const htmlCodeGenerator = new Blockly.Generator('HTML');
 
@@ -7,7 +8,7 @@ const htmlCodeGenerator = new Blockly.Generator('HTML');
 
 // 함수: 태그 블록(html, head, body, p, button) 정보를 코드로 변환
 const transferTagBlockToCode = (tagName: string) => {
-  htmlCodeGenerator.forBlock[addPreviousTypeName(tagName)] = function (block) {
+  htmlCodeGenerator.forBlock[tagName] = function (block) {
     let cssClass = '';
     const cssClassBlock = block.getInputTargetBlock('css class'); // 블록에서 직접 연결된 블록을 가져옴
     if (cssClassBlock) {
@@ -15,7 +16,7 @@ const transferTagBlockToCode = (tagName: string) => {
     }
 
     const children = htmlCodeGenerator.statementToCode(block, 'children');
-    const code = `<${tagName} class="${cssClass}">\n${children}\n</${tagName}>`;
+    const code = `<${removePreviousTypeName(tagName)} class="${cssClass}">\n${children}\n</${removePreviousTypeName(tagName)}>`;
     return code;
   };
 };
@@ -54,7 +55,11 @@ htmlCodeGenerator.scrub_ = function (block, code, thisOnly) {
 
 transferTagBlockToCode('html');
 transferTagBlockToCode('body');
-transferTagBlockToCode('p');
-transferTagBlockToCode('button');
+
+Object.values(blockContents).forEach((blockInfoList) => {
+  blockInfoList.forEach((blockInfo) => {
+    transferTagBlockToCode(blockInfo.type);
+  });
+});
 
 export default htmlCodeGenerator;

--- a/apps/client/src/widgets/workspace/blockly/htmlTagToolboxConfig.ts
+++ b/apps/client/src/widgets/workspace/blockly/htmlTagToolboxConfig.ts
@@ -39,5 +39,11 @@ export const htmlTagToolboxConfig = {
       categorystyle: 'linkCategory',
       contents: blockContents.link,
     },
+    {
+      kind: 'category',
+      name: '기타',
+      categorystyle: 'etcCategory',
+      contents: blockContents.etc,
+    },
   ],
 };

--- a/apps/client/src/widgets/workspace/blockly/htmlTagToolboxConfig.ts
+++ b/apps/client/src/widgets/workspace/blockly/htmlTagToolboxConfig.ts
@@ -1,4 +1,4 @@
-import { htmlBlockContents } from './htmlBlockContents';
+import { blockContents } from './htmlBlockContents';
 
 export const htmlTagToolboxConfig = {
   kind: 'categoryToolbox',
@@ -7,43 +7,37 @@ export const htmlTagToolboxConfig = {
       kind: 'category',
       name: '컨테이너',
       categorystyle: 'containerCategory',
-      contents: htmlBlockContents,
+      contents: blockContents.container,
     },
     {
       kind: 'category',
       name: '텍스트',
       categorystyle: 'textCategory',
-      contents: htmlBlockContents,
+      contents: blockContents.text,
     },
     {
       kind: 'category',
       name: '폼',
       categorystyle: 'formCategory',
-      contents: htmlBlockContents,
+      contents: blockContents.form,
     },
     {
       kind: 'category',
       name: '표',
       categorystyle: 'tableCategory',
-      contents: htmlBlockContents,
+      contents: blockContents.table,
     },
     {
       kind: 'category',
       name: '리스트',
       categorystyle: 'listCategory',
-      contents: htmlBlockContents,
+      contents: blockContents.list,
     },
     {
       kind: 'category',
       name: '링크',
       categorystyle: 'linkCategory',
-      contents: htmlBlockContents,
-    },
-    {
-      kind: 'category',
-      name: '기타',
-      categorystyle: 'etcCategory',
-      contents: htmlBlockContents,
+      contents: blockContents.link,
     },
   ],
 };

--- a/apps/client/src/widgets/workspace/blockly/initBlocks.ts
+++ b/apps/client/src/widgets/workspace/blockly/initBlocks.ts
@@ -1,0 +1,89 @@
+import { addPreviousTypeName } from '@/shared/utils';
+import * as Blockly from 'blockly/core';
+
+type InitialBlockDefinition = {
+  type: string;
+  coordinate?: { x: number; y: number };
+  movable?: boolean;
+  connection?: {
+    parent: string;
+    input: string;
+  };
+};
+
+export const initialBlocksJson: InitialBlockDefinition[] = [
+  {
+    type: addPreviousTypeName('html'),
+    coordinate: { x: 40, y: 40 },
+    movable: false,
+  },
+  {
+    type: addPreviousTypeName('head'),
+    connection: {
+      parent: 'html',
+      input: 'children',
+    },
+    movable: false,
+  },
+  {
+    type: addPreviousTypeName('body'),
+    connection: {
+      parent: 'html',
+      input: 'children',
+    },
+    movable: false,
+  },
+];
+
+export function initializeBlocks(workspace: Blockly.WorkspaceSvg) {
+  const createdBlocks: Record<string, Blockly.Block> = {};
+
+  initialBlocksJson.forEach((blockDefinition) => {
+    const { type, coordinate, movable, connection } = blockDefinition;
+
+    const block = workspace.newBlock(type);
+    if (coordinate) {
+      block.moveBy(coordinate.x, coordinate.y);
+    }
+    if (movable === false) {
+      block.setMovable(false);
+    }
+
+    block.initSvg();
+    block.render();
+
+    createdBlocks[type] = block;
+
+    if (connection) {
+      const parentBlock = createdBlocks[addPreviousTypeName(connection.parent)];
+      const childBlock = block;
+
+      if (parentBlock && childBlock) {
+        const inputConnection = parentBlock.getInput(connection.input)?.connection;
+
+        if (inputConnection) {
+          const lastBlock = findLastBlockInInput(parentBlock, connection.input);
+          if (lastBlock) {
+            lastBlock.nextConnection?.connect(childBlock.previousConnection);
+          } else {
+            inputConnection.connect(childBlock.previousConnection);
+          }
+        }
+      }
+    }
+  });
+
+  function findLastBlockInInput(block: Blockly.Block, inputName: string): Blockly.Block | null {
+    const input = block.getInput(inputName);
+    if (!input?.connection?.targetBlock()) {
+      return null;
+    }
+
+    let currentBlock = input.connection.targetBlock();
+    while (currentBlock?.nextConnection?.targetBlock()) {
+      currentBlock = currentBlock.nextConnection.targetBlock();
+    }
+
+    return currentBlock;
+  }
+}


### PR DESCRIPTION
> PR 제목은 핵심 변경 사항을 요약해주세요.
> [#이슈번호] (핵심 변경 사항)

---

## 🔗 Linked Issue (이슈)
#32 

## 🙋‍ Summary (요약) 
- 'html', 'head', 'body' 블록 캔버스에 고정시키기

## 😎 Description (변경사항)
### 'html', 'head', 'body' 블록 캔버스에 고정시키기

https://github.com/user-attachments/assets/a05da383-ae85-4e24-abeb-9348e8d07fc7

- html, head, body 블록을 캔버스에 기본적으로 생성해두고 해당 블록은 캔버스에 2개 이상 생성할 수 없도록 toolbox에서 제거했습니다. 
- 그리고 위치를 고정하고 블록을 삭제할 수 없도록 만들었습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
