### PR TITLE
[#34] undo/redo 기능 추가

### DIFF
--- a/apps/client/src/entities/workspace/RedoButton.tsx
+++ b/apps/client/src/entities/workspace/RedoButton.tsx
@@ -1,11 +1,18 @@
 import { CircleButton } from '@/shared/ui';
 import RightArrow from '@/shared/assets/arrow_right.svg?react';
+import { useWorkspaceStore } from '@/shared/store';
 
-// TODO: feature는 이사
-// TODO: Redo 기능 추가
 export const RedoButton = () => {
+  const { workspace } = useWorkspaceStore();
+
+  const handleRedo = () => {
+    if (workspace !== null) {
+      workspace.undo(true);
+    }
+  };
+
   return (
-    <CircleButton onClick={() => {}} width="w-[30px]" height="h-[30px]">
+    <CircleButton onClick={handleRedo} width="w-[30px]" height="h-[30px]">
       <RightArrow />
     </CircleButton>
   );

--- a/apps/client/src/entities/workspace/UndoButton.tsx
+++ b/apps/client/src/entities/workspace/UndoButton.tsx
@@ -1,10 +1,18 @@
 import { CircleButton } from '@/shared/ui';
 import LeftArrow from '@/shared/assets/arrow_left.svg?react';
+import { useWorkspaceStore } from '@/shared/store';
 
-// TODO: Undo 로직 추가
 export const UndoButton = () => {
+  const { workspace } = useWorkspaceStore();
+
+  const handleUndo = () => {
+    if (workspace !== null) {
+      workspace.undo(false);
+    }
+  };
+
   return (
-    <CircleButton onClick={() => {}} width="w-[30px]" height="h-[30px]">
+    <CircleButton onClick={handleUndo} width="w-[30px]" height="h-[30px]">
       <LeftArrow />
     </CircleButton>
   );

--- a/apps/client/src/shared/store/index.ts
+++ b/apps/client/src/shared/store/index.ts
@@ -4,3 +4,4 @@ export { useCssPropsStore } from './useCssPropsStore';
 export { useCssTooltipStore } from './useCssTooptipStore';
 export { useClassBlockStore } from './useClassBlockStore';
 export { useResetCssStore } from './useResetCssStore';
+export { useWorkspaceStore } from './useWorkspaceStore';

--- a/apps/client/src/shared/store/useWorkspaceStore.ts
+++ b/apps/client/src/shared/store/useWorkspaceStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import * as Blockly from 'blockly/core';
+
+type Tworkspace = {
+  workspace: Blockly.WorkspaceSvg | null;
+  setWorkspace: (newWorkspace: Blockly.WorkspaceSvg) => void;
+};
+
+export const useWorkspaceStore = create<Tworkspace>((set) => ({
+  workspace: null,
+  setWorkspace: (newWorkspace: Blockly.WorkspaceSvg) => {
+    set({ workspace: newWorkspace });
+  },
+}));

--- a/apps/client/src/widgets/workspace/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent.tsx
@@ -13,7 +13,7 @@ import {
   cssCodeGenerator,
 } from '@/widgets';
 
-import { useCssPropsStore } from '@/shared/store';
+import { useCssPropsStore, useWorkspaceStore } from '@/shared/store';
 import FixedFlyout from '@/core/fixedFlyout';
 import TabbedToolbox from '@/core/tabbedToolbox';
 import { registerCustomComponents } from '@/core/register';
@@ -29,6 +29,7 @@ export const WorkspaceContent = () => {
   const [htmlCode, setHtmlCode] = useState<string>('');
   const [cssCode, setCssCode] = useState<string>('');
   const { totalCssPropertyObj } = useCssPropsStore();
+  const { workspace, setWorkspace } = useWorkspaceStore();
 
   useEffect(() => {
     const newWorkspace = Blockly.inject('blocklyDiv', {
@@ -55,6 +56,8 @@ export const WorkspaceContent = () => {
 
     initializeBlocks(newWorkspace);
 
+    newWorkspace.clearUndo();
+
     // workspace 변화 감지해 자동 변환
     const handleAutoConversion = (event: Blockly.Events.Abstract) => {
       if (
@@ -70,6 +73,10 @@ export const WorkspaceContent = () => {
     };
 
     newWorkspace.addChangeListener(handleAutoConversion);
+
+    if (workspace === null) {
+      setWorkspace(newWorkspace);
+    }
 
     return () => {
       newWorkspace.removeChangeListener(handleAutoConversion);


### PR DESCRIPTION
## 🔗 Linked Issue (#34, #141)

## 🙋‍ Summary (요약) 
- undo/redo 기능 추가
- 기본적으로 캔버스에 올라가있는 svg
- 기본 설정 블록들이 뒤로가기 누르면 분리되고 사라지는 버그 수정

## 😎 Description (변경사항)
### Blockly.WorkspaceSvg 내 undo 메소드
- Blockly.WorkspaceSvg 클래스 내에는 undo 메소드가 있습니다. (정확히는 상속받아 사용하는 클래스인 workspace에 있습니다.)
- 이 메소드는 public 메소드이기에 undo/redo 컴포넌트에서 저희가 만든 workspace 인스턴스에 접근할 수만 있다면 쉽게 동작할 수 있겠다고 생각했습니다.
- zustand를 이용해 workspaceStore를 만들었습니다.
```js
import { create } from 'zustand';
import * as Blockly from 'blockly/core';

type Tworkspace = {
  workspace: Blockly.WorkspaceSvg | null;
  setWorkspace: (newWorkspace: Blockly.WorkspaceSvg) => void;
};

export const useWorkspaceStore = create<Tworkspace>((set) => ({
  workspace: null,
  setWorkspace: (newWorkspace: Blockly.WorkspaceSvg) => {
    set({ workspace: newWorkspace });
  },
}));
```

- 이를 외부 undo/redo 컴포넌트에서 workspace가 null이 아닐 시 undo/redo 동작이 먹힐 수 있게 동작함수를 할당해주었습니다.
```js
...
  const { workspace } = useWorkspaceStore();

  const handleUndo = () => {
    if (workspace !== null) {
      workspace.undo(false);
    }
  };
...
```

- 기본 설정 블록들이 뒤로가기 누르면 분리되고 사라지는 버그 수정
```js
newWorkspace.clearUndo();
```
- 이 메소드를 실행하면 쌓여있는 history stack을 없애줘서 뒤로가기 버튼을 누르면 기존 블록이 사라지던 버그를 고쳤습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
