### PR TITLE
[#25] 블록에 커스텀 툴팁이 보이게 구현

### DIFF
--- a/apps/client/src/app/index.css
+++ b/apps/client/src/app/index.css
@@ -58,6 +58,10 @@
   .text-medium-sm {
     @apply text-xs font-medium leading-4;
   }
+
+  .text-tooltip-sm {
+    @apply text-xs font-medium leading-[1.15rem];
+  }
 }
 
 .blocklyToolboxDiv {
@@ -200,4 +204,8 @@ input[type='color']::-webkit-color-swatch-wrapper {
 .resetCssText {
   @apply text-gray-400;
   padding: 0 6px 0 12px;
+}
+
+.blocklyTooltipDiv {
+  @apply text-gray-white text-tooltip-sm rounded-md border-none bg-green-500 px-3 py-2 opacity-100;
 }

--- a/apps/client/src/core/customTooltip.ts
+++ b/apps/client/src/core/customTooltip.ts
@@ -1,0 +1,9 @@
+import * as Blockly from 'blockly/core';
+
+export const customTooltip = (p1: Element, p2: Element): void => {
+  const content = document.createElement('p');
+  content.style.whiteSpace = 'pre-wrap';
+  content.style.fontFamily = 'SUIT Variable';
+  content.textContent = (p2 as unknown as Blockly.BlockSvg).getTooltip();
+  p1.appendChild(content);
+};

--- a/apps/client/src/entities/workspace/CssTooltip.tsx
+++ b/apps/client/src/entities/workspace/CssTooltip.tsx
@@ -13,7 +13,7 @@ export const CssTooltip = ({ description, isOpen, leftX, topY }: CssTooltipProps
   }
   return createPortal(
     <div
-      className={`text-gray-white fixed left-0 top-0 z-[9999] rounded-3xl ${topY >= 0 ? 'rounded-tl-none' : 'rounded-bl-none'} bg-green-500 px-3 py-2`}
+      className={`text-gray-white text-tooltip-sm fixed left-0 top-0 z-[9999] rounded-3xl ${topY >= 0 ? 'rounded-tl-none' : 'rounded-bl-none'} bg-green-500 px-3 py-2`}
       style={{ left: `${leftX + 18}px`, top: topY >= 0 ? `${topY + 8}px` : `${-topY}px` }}
     >
       <p>{description}</p>

--- a/apps/client/src/widgets/workspace/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent.tsx
@@ -23,9 +23,12 @@ import CustomZoomControls from '@/core/customZoomControls';
 import CustomTrashcan from '@/core/customTrashcan';
 import { blockContents } from './blockly/htmlBlockContents';
 import { initializeBlocks } from './blockly/initBlocks';
+import { customTooltip } from '@/core/customTooltip';
 
 registerCustomComponents();
 defineBlocks(blockContents);
+
+Blockly.Tooltip.setCustomTooltip(customTooltip);
 
 Blockly.WorkspaceSvg.prototype.addZoomControls = function () {
   this.zoomControls_ = new CustomZoomControls(this);

--- a/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
+++ b/apps/client/src/widgets/workspace/blockly/defineBlocks.ts
@@ -1,4 +1,3 @@
-import { CustomFieldLabelSerializable } from '@/core/customFieldLabelSerializable';
 import { CustomFieldTextInput } from '@/core/customFieldTextInput';
 import { TBlockContents } from '@/shared/types';
 import { addPreviousTypeName, removePreviousTypeName } from '@/shared/utils';
@@ -14,6 +13,7 @@ import * as Blockly from 'blockly/core';
 const defineBlockWithDefaults = (
   blockName: string,
   blockColorNum: number | string,
+  description: string,
   blockDefinition: any = { init: function () {} },
   isDefault: boolean = true
 ) => {
@@ -23,6 +23,7 @@ const defineBlockWithDefaults = (
 
     if (!this.styleName_) {
       this.setStyle(`defaultBlock${blockColorNum}`);
+      this.setTooltip(description);
     }
 
     if (isDefault) {
@@ -42,6 +43,7 @@ export const defineBlocks = (blockContents: TBlockContents) => {
   defineBlockWithDefaults(
     addPreviousTypeName('html'),
     1,
+    '웹페이지의 시작과 끝을 알려주는 가장 큰 상자예요.\n모든 내용을 담고 있는 책의 겉표지 같은 거예요.',
     {
       init: function () {
         this.appendDummyInput().appendField('html');
@@ -54,6 +56,7 @@ export const defineBlocks = (blockContents: TBlockContents) => {
   defineBlockWithDefaults(
     addPreviousTypeName('head'),
     2,
+    '웹페이지의 정보를 담아두는 곳이에요.\n책의 목차나 출판 정보같이 보이지 않지만 중요한 정보들이 들어가요.',
     {
       init: function () {
         this.setPreviousStatement(true);
@@ -64,7 +67,11 @@ export const defineBlocks = (blockContents: TBlockContents) => {
     false
   );
 
-  defineBlockWithDefaults(addPreviousTypeName('body'), 3);
+  defineBlockWithDefaults(
+    addPreviousTypeName('body'),
+    3,
+    '웹페이지에서 실제로 보이는 모든 내용이 들어가는 곳이에요.\n책의 실제 내용이 적힌 부분같은 거예요.'
+  );
 
   /*
    *   {
@@ -79,6 +86,7 @@ export const defineBlocks = (blockContents: TBlockContents) => {
         defineBlockWithDefaults(
           blockInfo.type,
           (index % 3) + 1,
+          blockInfo.description,
           {
             init: function () {
               this.setPreviousStatement(true); // 다른 블록 위에 연결 가능
@@ -86,6 +94,7 @@ export const defineBlocks = (blockContents: TBlockContents) => {
               this.appendDummyInput()
                 .appendField(removePreviousTypeName(blockInfo.type))
                 .appendField(new CustomFieldTextInput(), 'TEXT');
+              this.setTooltip(blockInfo.description);
             },
           },
           false
@@ -97,6 +106,7 @@ export const defineBlocks = (blockContents: TBlockContents) => {
         defineBlockWithDefaults(
           blockInfo.type,
           (index % 3) + 1,
+          blockInfo.description,
           {
             init: function () {
               this.setPreviousStatement(true);
@@ -107,20 +117,8 @@ export const defineBlocks = (blockContents: TBlockContents) => {
           false
         );
       } else {
-        defineBlockWithDefaults(blockInfo.type, (index % 3) + 1);
+        defineBlockWithDefaults(blockInfo.type, (index % 3) + 1, blockInfo.description);
       }
     });
   });
-
-  defineBlockWithDefaults(
-    'css_style',
-    'Css',
-    {
-      init: function () {
-        this.appendDummyInput().appendField(new CustomFieldLabelSerializable('클래스명'), 'CLASS'); // "클래스명"은 초기값
-        this.setOutput(true); // 이 블록을 다른 블록에 연결할 수 있도록 설정
-      },
-    },
-    false
-  );
 };

--- a/apps/client/src/widgets/workspace/blockly/htmlBlockContents.ts
+++ b/apps/client/src/widgets/workspace/blockly/htmlBlockContents.ts
@@ -5,22 +5,22 @@ const containerBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('div'),
-    description: '여러 내용을 담을 수 있는 상자예요. 레고 블록처럼 여러 개를 쌓을 수 있어요.',
+    description: `여러 내용을 담을 수 있는 상자예요.\n레고 블록처럼 여러 개를 쌓을 수 있어요.`,
   },
   {
     kind: 'block',
     type: addPreviousTypeName('span'),
-    description: '글자나 작은 내용을 감싸는 작은 상자예요. 문장 중간에 넣을 수 있어요.',
+    description: '글자나 작은 내용을 감싸는 작은 상자예요.\n문장 중간에 넣을 수 있어요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('header'),
-    description: '웹페이지의 머리 부분이에요. 보통 로고나 메뉴가 들어가는 곳이에요.',
+    description: '웹페이지의 머리 부분이에요.\n보통 로고나 메뉴가 들어가는 곳이에요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('section'),
-    description: '비슷한 내용들을 모아두는 구역이에요. 책의 한 챕터같은 거예요.',
+    description: '비슷한 내용들을 모아두는 구역이에요.\n책의 한 챕터같은 거예요.',
   },
   {
     kind: 'block',
@@ -30,17 +30,17 @@ const containerBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('main'),
-    description: '페이지에서 가장 중요한 내용이 들어가는 곳이에요. 책의 본문 같은 거예요.',
+    description: '페이지에서 가장 중요한 내용이 들어가는 곳이에요.\n책의 본문 같은 거예요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('article'),
-    description: '하나의 완성된 이야기나 내용을 담는 곳이에요. 신문 기사처럼요.',
+    description: '하나의 완성된 이야기나 내용을 담는 곳이에요.\n신문 기사처럼요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('footer'),
-    description: '웹페이지의 맨 아래 부분이에요. 주소나 연락처 같은 정보가 들어가요.',
+    description: '웹페이지의 맨 아래 부분이에요.\n주소나 연락처 같은 정보가 들어가요.',
   },
 ];
 
@@ -48,7 +48,7 @@ const textBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('p'),
-    description: '문단을 만드는 태그예요. 하나의 생각이나 이야기를 묶어서 쓸 때 사용해요.',
+    description: '문단을 만드는 태그예요.\n하나의 생각이나 이야기를 묶어서 쓸 때 사용해요.',
   },
   {
     kind: 'block',
@@ -58,42 +58,42 @@ const textBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('h1'),
-    description: '가장 큰 제목을 쓸 때 사용해요. 책의 제목같은 거예요.',
+    description: '가장 큰 제목을 쓸 때 사용해요.\n책의 제목같은 거예요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('h2'),
-    description: '두 번째로 큰 제목이에요. 책의 장(章) 제목 같은 거예요.',
+    description: '두 번째로 큰 제목이에요.\n책의 장(章) 제목 같은 거예요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('h3'),
-    description: '세 번째로 큰 제목이에요. 책의 절(節) 제목 같은 거예요.',
+    description: '세 번째로 큰 제목이에요.\n책의 절(節) 제목 같은 거예요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('h4'),
-    description: '네 번째로 큰 제목이에요. 작은 주제를 쓸 때 사용해요.',
+    description: '네 번째로 큰 제목이에요.\n작은 주제를 쓸 때 사용해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('h5'),
-    description: '다섯 번째로 큰 제목이에요. 아주 작은 주제를 쓸 때 사용해요.',
+    description: '다섯 번째로 큰 제목이에요.\n아주 작은 주제를 쓸 때 사용해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('h6'),
-    description: '가장 작은 제목이에요. 제일 세세한 주제를 쓸 때 사용해요.',
+    description: '가장 작은 제목이에요.\n제일 세세한 주제를 쓸 때 사용해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('small'),
-    description: '작은 글씨로 보여주고 싶을 때 사용해요. 부가 설명을 쓸 때 좋아요.',
+    description: '작은 글씨로 보여주고 싶을 때 사용해요.\n부가 설명을 쓸 때 좋아요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('br'),
-    description: '줄을 바꾸고 싶을 때 사용해요. 엔터 키를 누른 것처럼요.',
+    description: '줄을 바꾸고 싶을 때 사용해요.\n엔터 키를 누른 것처럼요.',
   },
   {
     kind: 'block',
@@ -108,7 +108,7 @@ const textBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('blockquote'),
-    description: '다른 사람의 말을 인용할 때 사용해요. 책에서 따온 문장 같은 거예요.',
+    description: '다른 사람의 말을 인용할 때 사용해요.\n책에서 따온 문장 같은 거예요.',
   },
   {
     kind: 'block',
@@ -121,22 +121,22 @@ const formBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('button'),
-    description: '클릭할 수 있는 버튼이에요. 제출하기나 확인 같은 동작을 할 때 사용해요.',
+    description: '클릭할 수 있는 버튼이에요.\n제출하기나 확인 같은 동작을 할 때 사용해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('option'),
-    description: '선택할 수 있는 항목 하나를 나타내요. 여러 가지 중에 고를 수 있어요.',
+    description: '선택할 수 있는 항목 하나를 나타내요.\n여러 가지 중에 고를 수 있어요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('textarea'),
-    description: '긴 글을 쓸 수 있는 큰 입력창이에요. 게시글이나 댓글을 쓸 때 사용해요.',
+    description: '긴 글을 쓸 수 있는 큰 입력창이에요.\n게시글이나 댓글을 쓸 때 사용해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('select'),
-    description: '여러 개 중에서 하나를 선택할 수 있는 목록이에요. 드롭다운 메뉴같은 거예요.',
+    description: '여러 개 중에서 하나를 선택할 수 있는 목록이에요.\n드롭다운 메뉴같은 거예요.',
   },
 ];
 
@@ -144,27 +144,27 @@ const tableBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('td'),
-    description: '표의 칸 하나예요. 내용을 채워 넣을 수 있어요.',
+    description: '표의 칸 하나예요.\n내용을 채워 넣을 수 있어요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('tr'),
-    description: '표의 가로줄 하나예요. 여러 칸을 옆으로 나열할 수 있어요.',
+    description: '표의 가로줄 하나예요.\n여러 칸을 옆으로 나열할 수 있어요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('th'),
-    description: '표의 제목 칸이에요. 각 항목이 무엇을 의미하는지 설명해요.',
+    description: '표의 제목 칸이에요.\n각 항목이 무엇을 의미하는지 설명해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('caption'),
-    description: '표의 제목이에요. 표가 어떤 내용인지 설명해줘요.',
+    description: '표의 제목이에요.\n표가 어떤 내용인지 설명해줘요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('table'),
-    description: '표를 만들 때 사용해요. 시간표나 성적표 같은 걸 만들 수 있어요.',
+    description: '표를 만들 때 사용해요.\n시간표나 성적표 같은 걸 만들 수 있어요.',
   },
 ];
 
@@ -172,17 +172,17 @@ const listBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('ul'),
-    description: '순서가 없는 목록을 만들어요. 점이나 동그라미로 항목을 구분해요.',
+    description: '순서가 없는 목록을 만들어요.\n점이나 동그라미로 항목을 구분해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('ol'),
-    description: '순서가 있는 목록을 만들어요. 1, 2, 3처럼 숫자로 항목을 구분해요.',
+    description: '순서가 있는 목록을 만들어요.\n1, 2, 3처럼 숫자로 항목을 구분해요.',
   },
   {
     kind: 'block',
     type: addPreviousTypeName('li'),
-    description: '목록의 각 항목이에요. 하나하나의 내용을 적을 수 있어요.',
+    description: '목록의 각 항목이에요.\n하나하나의 내용을 적을 수 있어요.',
   },
 ];
 
@@ -190,7 +190,7 @@ const etcBlockContents: TBlockInfo[] = [
   {
     kind: 'block',
     type: addPreviousTypeName('text'),
-    description: '일반 글자를 보여주는 기본 텍스트예요. 특별한 꾸밈이 없는 평범한 글자랍니다.',
+    description: '일반 글자를 보여주는 기본 텍스트예요.\n특별한 꾸밈이 없는 평범한 글자랍니다.',
   },
 ];
 


### PR DESCRIPTION
## 🔗 Linked Issue (#25)

## 🙋‍ Summary (요약) 
- 블록에 커스텀 툴팁이 보이게 구현
- 툴팁 css 스타일 속성 및 description 일부 수정

## 😎 Description (변경사항)
### 블록에 커스텀 툴팁이 보이게 구현
![_2024_11_27_16_00_10_666-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c04b4d81-ca2c-4d75-a67b-70953fc6114f)

- 블록리 내 customToolTip 이라는 커스텀 툴팁 등록 함수와, blocklyTooltipBox 라는 클래스명을 이용하여 툴팁 커스텀하였습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
