### PR TITLE
[#157] 워크스페이스 이름 변경 시 상태 관리 미적용, 워크스페이스에 저장된 블록이 있음에도 새로 고침 시 초기화 되는 문제 해결

### DIFF
--- a/apps/client/src/shared/api/workspaceApi.ts
+++ b/apps/client/src/shared/api/workspaceApi.ts
@@ -5,7 +5,7 @@ import {
   TGetWorkspaceResponse,
   TPagedWorkspaceListResultDto,
   TTotalCssPropertyObj,
-  TWorkspace,
+  TWorkspaceDto,
 } from '@/shared/types';
 
 import { Instance } from '@/shared/api';
@@ -47,7 +47,7 @@ export const WorkspaceApi = () => {
       { workspaceId, newName },
       { headers: { 'user-id': userId } }
     );
-    return response.data as TWorkspace;
+    return response.data as TWorkspaceDto;
   };
 
   const deleteWorkspace = async (userId: string, workspaceId: string): Promise<void> => {

--- a/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
@@ -1,14 +1,13 @@
 import { TCanvas, TTotalCssPropertyObj } from '@/shared/types/workspaceType';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { TBlock } from '@/shared/types';
 import { WorkspaceApi } from '@/shared/api';
 import { getUserId } from '@/shared/utils';
 import toast from 'react-hot-toast';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useWorkspaceChangeStatusStore } from '@/shared/store';
 import { workspaceKeys } from '../query-key/workspaceKeys';
-import { TBlock } from '@/shared/types';
 
-// TODO : 블록 상태도 저장해야함 Promise.all로 처리할 예정
 export const useSaveWorkspace = (workspaceId: string) => {
   const workspaceApi = WorkspaceApi();
   const userId = getUserId();

--- a/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
+++ b/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
@@ -16,14 +16,7 @@ export const useUpdateWorkspaceName = () => {
     },
     onSuccess: (data) => {
       toast.success('워크스페이스 이름이 변경되었습니다.');
-      queryClient.setQueryData(workspaceKeys.detail(data.workspace_id), {
-        workspaceDto: {
-          name: data.name,
-          workspaceId: data.workspace_id,
-          isCssRest: data.isCssReset,
-          totalCssPropertyObj: data.totalTotalCssPropertyObj,
-        },
-      });
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.detail(data.workspaceId) });
       queryClient.invalidateQueries({ queryKey: workspaceKeys.list() });
     },
     onError: () => {

--- a/apps/client/src/shared/types/workspaceType.ts
+++ b/apps/client/src/shared/types/workspaceType.ts
@@ -28,9 +28,9 @@ export type TPagedWorkspaceListResult = {
 
 export type TWorkspace = {
   name: string;
-  updatedAt: string;
-  userId: string;
-  workspaceId: string;
+  updated_at: string;
+  user_id: string;
+  workspace_id: string;
   thumbnail: string | undefined;
   isCssReset: boolean;
   totalTotalCssPropertyObj: TTotalCssPropertyObj;

--- a/apps/client/src/shared/types/workspaceType.ts
+++ b/apps/client/src/shared/types/workspaceType.ts
@@ -17,6 +17,8 @@ export type TWorkspaceDto = {
   totalCssPropertyObj: TTotalCssPropertyObj;
   canvas: string;
   classBlockList: string;
+  thumbnail: string;
+  updatedAt: string;
 };
 
 export type TPagedWorkspaceListResult = {
@@ -26,9 +28,9 @@ export type TPagedWorkspaceListResult = {
 
 export type TWorkspace = {
   name: string;
-  updated_at: string;
-  user_id: string;
-  workspace_id: string;
+  updatedAt: string;
+  userId: string;
+  workspaceId: string;
   thumbnail: string | undefined;
   isCssReset: boolean;
   totalTotalCssPropertyObj: TTotalCssPropertyObj;

--- a/apps/client/src/widgets/workspace/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent.tsx
@@ -104,7 +104,7 @@ export const WorkspaceContent = () => {
   }, []);
 
   useEffect(() => {
-    if (!workspace || canvasInfo.length === 0) {
+    if (!workspace || !canvasInfo || canvasInfo.length === 0) {
       return;
     }
     Blockly.serialization.workspaces.load(JSON.parse(canvasInfo), workspace);

--- a/apps/client/src/widgets/workspace/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent.tsx
@@ -104,11 +104,11 @@ export const WorkspaceContent = () => {
   }, []);
 
   useEffect(() => {
-    if (!workspace || !canvasInfo || canvasInfo.length === 0) {
+    if (!workspace || canvasInfo.length === 0) {
       return;
     }
     Blockly.serialization.workspaces.load(JSON.parse(canvasInfo), workspace);
-  }, [workspace]);
+  }, [workspace, canvasInfo]);
 
   useEffect(() => {
     setCssCode(cssCodeGenerator(totalCssPropertyObj));

--- a/apps/server/src/services/workspaceService.ts
+++ b/apps/server/src/services/workspaceService.ts
@@ -106,6 +106,9 @@ export const WorkspaceService = () => {
         isCssReset: updatedWorkspace.is_css_reset,
         totalCssPropertyObj,
         canvas: updatedWorkspace.canvas,
+        userId: updatedWorkspace.user_id,
+        updatedAt: updatedWorkspace.updated_at,
+        thumbnail: updatedWorkspace.thumbnail,
       };
     } catch (error) {
       if (error instanceof Error) {


### PR DESCRIPTION
## 🔗 #157 

## 🙋‍ Summary (요약) 
- useUpdateWorkspaceName 커스텀 훅 수정
- workspace에 블록 load 하는 방식 수정

## 😎 Description (변경사항)
### useUpdateWorkspaceName 커스텀 훅 수정
```tsx
    onSuccess: (data) => {
      toast.success('워크스페이스 이름이 변경되었습니다.');
      queryClient.invalidateQueries({ queryKey: workspaceKeys.detail(data.workspaceId) });
      queryClient.invalidateQueries({ queryKey: workspaceKeys.list() });
    },
```
- 서버에서 반환하는 업데이트된 workspace 속성이 전부 파스칼 케이스로 변경됨
  - data의 속성이 파스칼 케이스로 변경됨에 따라 `workspace_id` => `workspaceId`로 변경했습니다.
### workspace 블록 load 방식 수정
```tsx
  useEffect(() => {
    if (!workspace || canvasInfo.length === 0) {
      return;
    }
    Blockly.serialization.workspaces.load(JSON.parse(canvasInfo), workspace);
  }, [workspace, canvasInfo]);

```
- useEffect 의존성 배열에 `workspace`만 포함되어 워크스페이스 페이지 로딩 시 `canvasInfo`의 데이터가 변경되어도 `workspace`에 반영되지 않는 문제가 있어 의존성 배열에 `canvasInfo`를 추가하였습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
