### PR TITLE
[#165] https 환경으로 배포

### DIFF
--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Set Nginx SSL files
         run: |
+          mkdir -p apps/client/ssl
           echo "${{ secrets.SSL_FULLCHAIN }}" > apps/client/ssl/fullchain.pem
           echo "${{ secrets.SSL_PRIVKEY }}" > apps/client/ssl/privkey.pem
 

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Set Nginx SSL files
         run: |
+          mkdir -p /apps/client/ssl
           echo "${{ secrets.SSL_FULLCHAIN }}" > /apps/client/ssl/fullchain.pem
           echo "${{ secrets.SSL_PRIVKEY }}" > /apps/client/ssl/privkey.pem
 

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -41,6 +41,11 @@ jobs:
           echo "VITE_SERVER_URL=http://localhost:3000" > apps/client/.env
           echo "VITE_STATIC_STORAGE_URL=${{ secrets.VITE_STATIC_STORAGE_URL }}" >> apps/client/.env
 
+      - name: Set Nginx SSL files
+        run: |
+          echo "${{ secrets.SSL_FULLCHAIN }}" > /apps/client/ssl/fullchain.pem
+          echo "${{ secrets.SSL_PRIVKEY }}" > /apps/client/ssl/privkey.pem
+
       - name: Buld Frontend
         run: |
           cd apps/client

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -43,9 +43,8 @@ jobs:
 
       - name: Set Nginx SSL files
         run: |
-          mkdir -p /apps/client/ssl
-          echo "${{ secrets.SSL_FULLCHAIN }}" > /apps/client/ssl/fullchain.pem
-          echo "${{ secrets.SSL_PRIVKEY }}" > /apps/client/ssl/privkey.pem
+          echo "${{ secrets.SSL_FULLCHAIN }}" > apps/client/ssl/fullchain.pem
+          echo "${{ secrets.SSL_PRIVKEY }}" > apps/client/ssl/privkey.pem
 
       - name: Buld Frontend
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,9 @@ Thumbs.db
 
 *storybook.log
 
-
 swagger-output.json
 
 # Ignore Storybook build folder
 storybook-static/
+
+ssl/

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -7,7 +7,13 @@ RUN pnpm run build
 
 FROM nginx:alpine AS frontend
 COPY --from=frontend-build /app/apps/client/dist /usr/share/nginx/html
-COPY --from=frontend-build /app/apps/client/public /usr/share/nginx/html
 COPY /apps/client/nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+COPY /apps/client/ssl /etc/nginx/ssl
+
+RUN chmod -R 755 /user/share/nginx/html
+RUN chmod 644 /etc/nginx/ssl/fullchain.pem
+RUN chmod 600 /etc/nginx/ssl/privkey.pem
+RUN chown -R nginx:nginx /user/share/nginx/html /etc/nginx/ssl
+
+EXPOSE 80 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -10,10 +10,10 @@ COPY --from=frontend-build /app/apps/client/dist /usr/share/nginx/html
 COPY /apps/client/nginx.conf /etc/nginx/conf.d/default.conf
 COPY /apps/client/ssl /etc/nginx/ssl
 
-RUN chmod -R 755 /user/share/nginx/html
+RUN chmod -R 755 /usr/share/nginx/html
 RUN chmod 644 /etc/nginx/ssl/fullchain.pem
 RUN chmod 600 /etc/nginx/ssl/privkey.pem
-RUN chown -R nginx:nginx /user/share/nginx/html /etc/nginx/ssl
+RUN chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/ssl
 
 EXPOSE 80 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -1,5 +1,18 @@
 server {
     listen 80;
+    server_name boolock.site;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name boolock.site;
+
+    ssl_certificate /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
 
     location / {
         root /usr/share/nginx/html;
@@ -12,6 +25,16 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_cache_bypass $http_upgrade;
     }
+
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options SAMEORIGIN;
+    add_header X-XSS-Protection "1; mode=block";
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 256;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - base
     ports:
       - '80:80'
+      - '443:443'
 
   backend:
     build:


### PR DESCRIPTION
## 🔗 Linked Issue (#165)

## 🙋‍ Summary (요약)
- ssl 인증서 발급
- https 환경으로 배포 https://boolock.site/

## 😎 Description (변경사항)
### ssl 인증서 발급
- https://certbot.eff.org/ 여기서 무료로 ssl 인증서 발급해준다길래 사용했습니다.
- 저희 서버 ssh 터미널에서 아래와 같은 명령어를 치고 인증서를 발급받았습니다.
```
sudo apt install certbot
sudo certbot certonly --standalone -d boolock.site
```
- 발급받은 인증서는 `/etc/letsencrypt/live/boolock.site/` 경로로 설치됩니다.
- apps/client/ssl 경로 내에 인증서 파일과 키를 카피해두고 ingnore 설정해주었습니다.

- 인증서를 다운받고 위치시키는 것도 certbot 컨테이너로 해서 docker로 할 수 있고, 캐시로 저장도 되나 그냥 서버를 변경하지 않으니 서버 내에서 발급받고 copy해와서 사용하기로 결정했습니다.

### https 환경으로 배포
- https 환경으로 배포하기 위해 nginx 파일과 client docker파일을 수정하였습니다.
```
// nginx
server {
    listen 80;
    server_name boolock.site;

    location / {
        return 301 https://$host$request_uri;
    }
}
```
- 80번 포트로 들어오는 요청들은 https 경로로 리다이렉션되게 해두었습니다.
```
// nginx
server {
    listen 443 ssl;
    server_name boolock.site;

    ssl_certificate /etc/nginx/ssl/fullchain.pem;
    ssl_certificate_key /etc/nginx/ssl/privkey.pem;

   // .. 일부 설정 제외하고 동일

    add_header X-Content-Type-Options nosniff;
    add_header X-Frame-Options SAMEORIGIN;
    add_header X-XSS-Protection "1; mode=block";

    gzip on;
    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
    gzip_min_length 256;
}
```
- 443번 포트로 들어오는 것은 ssl 인증서로 검증을 받게 됩니다.
- `/etc/nginx/ssl/` 해당 경로에 들어가있는 인증서를 가져옵니다.
  - 이를 위해 docker 이미지를 올릴 때 해당 경로에 ssl 인증서 파일을 위치시킵니다.
- 아래 추가된 스크립트들은 xss 공격 방지 등 보안 취약점을 방지하기 위한 nginx 설정이길래 넣어봤습니다.

```Dockerfile
FROM nginx:alpine AS frontend
COPY --from=frontend-build /app/apps/client/dist /usr/share/nginx/html
COPY /apps/client/nginx.conf /etc/nginx/conf.d/default.conf
COPY /apps/client/ssl /etc/nginx/ssl

RUN chmod -R 755 /user/share/nginx/html
RUN chmod 644 /etc/nginx/ssl/fullchain.pem
RUN chmod 600 /etc/nginx/ssl/privkey.pem
RUN chown -R nginx:nginx /user/share/nginx/html /etc/nginx/ssl

EXPOSE 80 443
CMD ["nginx", "-g", "daemon off;"]
```
- frontend nginx 배포시 Dockerfile 설정을 위와 같이 변경해두었습니다.
- ssl 인증서 파일을 가져오는 스크립트가 추가되었습니다.
- 각 nginx 폴더, 파일들과 ssl 폴더, 파일에 대한 권한을 지정해주는 스크립트를 추가해주었습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
### docker로 배포할 때 nginx user에 대한 파일 권한 문제 발생
- 배포를 했음에도 불구하고 배포사이트 주소로 들어가면 403 에러가 발생했습니다
- nginx.conf 코드가 잘 동작되는 코드인지 `docker exec -it <boolock-container-name> nginx -t` 으로 확인해보았을 때, 이슈는 없었습니다.
- docker log를 확인해본 결과
```
2024/11/28 07:09:19 [crit] 29#29: *3 stat() "/usr/share/nginx/html/index.html" failed (13: Permission denied), client: 1.229.198.186, server: boolock.site, request: "GET / HTTP/1.1", host: "boolock.site", referrer: "https://boolock.site/"
```
- 에러내용이 이랬는데 한마디로 `/usr/share/nginx/html/index.html` 이 경로에 있는 파일들에 대한 권한이 없어 접근할 수 없다는 것이었습니다.
![image](https://github.com/user-attachments/assets/10afda44-0546-49b1-bc0a-fe9e2d7add7a)
- 파일들 권한을 확인해보니 nginx를 구동하기 위한 권한들은 적절히 적용되어있습니다.
- `/usr/share/nginx/html/index.html` 이 경로에 있는 파일들에 대한 권한이 문제가 아니라면 해당 경로 디렉토리 자체에 대한 권한에 문제가 있었다는 뜻이 됩니다.
- 그래서 `docker exec -it <boolock-container-name> chmod -R 755 /usr/share/nginx/html` 이렇게 권한을 줘 보고, `docker exec -it <boolock-container-name> nginx -s reload` 이렇게 nginx만 재시작해서 확인해보니 **https 환경으로도 사이트에 잘 들어가졌습니다!**
- client Dockerfile에서 `RUN chmod -R 755 /user/share/nginx/html` 명령어를 추가해주고 docker를 다시 재빌드 하니 서버가 잘동작하였습니다. (원래는 644 권한을 부여해주었습니다.)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
