### PR TITLE
[#178] 워크스페이스화면에서 로고 이미지가 깨져보이는 오류 해결

### DIFF
--- a/apps/client/src/entities/home/NotHoveredEmptyWorkspace/NotHoveredEmptyWorkspace.tsx
+++ b/apps/client/src/entities/home/NotHoveredEmptyWorkspace/NotHoveredEmptyWorkspace.tsx
@@ -5,7 +5,7 @@
 export const NotHoveredEmptyWorkspace = () => {
   return (
     <div className="flex h-[23rem] flex-col items-center justify-center bg-gray-50 text-gray-200">
-      <img src="./images/empty_logo.png" alt="" className="h-40 w-40 grayscale" />
+      <img src="/images/empty_logo.png" alt="" className="h-40 w-40 grayscale" />
       <p className="text-center">
         아직 워크스페이스가 없어요! <br /> 새로운 웹 페이지를 만들어보세요!
       </p>

--- a/apps/client/src/entities/home/WorkspaceLoadError/WorkspaceLoadError.tsx
+++ b/apps/client/src/entities/home/WorkspaceLoadError/WorkspaceLoadError.tsx
@@ -6,7 +6,7 @@
 export const WorkspaceLoadError = () => {
   return (
     <div className="flex h-[23rem] w-full flex-col items-center justify-center gap-4 rounded-lg bg-gray-50 text-gray-200">
-      <img src="./images/not_found.png" className="h-40 w-40" />
+      <img src="/images/not_found.png" className="h-40 w-40" />
       <p className="text-center">워크스페이스를 불러오지 못했습니다.</p>
     </div>
   );

--- a/apps/client/src/pages/NotFound/NotFound.tsx
+++ b/apps/client/src/pages/NotFound/NotFound.tsx
@@ -21,7 +21,7 @@ export const NotFound = () => {
         <HomeHeader isBlack={false} />
 
         <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col gap-6">
-          <img src="./images/not_found.png" width={160} height={160} alt="not_found" />
+          <img src="/images/not_found.png" width={160} height={160} alt="not_found" />
           <p className="text-medium-md text-center text-gray-200">
             유효한 페이지가 아닙니다! <br />
             다른 페이지에서 만나요!

--- a/apps/client/src/shared/ui/logo/Logo.tsx
+++ b/apps/client/src/shared/ui/logo/Logo.tsx
@@ -15,7 +15,7 @@ export const Logo = ({ isBlack }: LogoProps) => {
   return (
     <Link to="/">
       <div className="flex items-center gap-3">
-        <img src="./images/boolock_logo.png" width={32} height={32} alt="Boolock Logo" />
+        <img src="/images/boolock_logo.png" width={32} height={32} alt="Boolock Logo" />
         {isBlack ? <WhiteLogoText className="w-28" /> : <BlackLogoText className="w-28" />}
       </div>
     </Link>

--- a/apps/client/src/shared/ui/modal/ModalConfirm.stories.tsx
+++ b/apps/client/src/shared/ui/modal/ModalConfirm.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {
         <ModalConfirm {...args} isOpen={isOpen}>
           <div className="flex flex-col items-center justify-center">
             <p>모달창입니다.</p>
-            <img src="./images/booduck_modal.png" alt="부덕이" width={100} height={100} />
+            <img src="/images/booduck_modal.png" alt="부덕이" width={100} height={100} />
             <button onClick={() => setIsOpen(false)}>닫기</button>
           </div>
         </ModalConfirm>

--- a/apps/client/src/widgets/home/HomeHeader/HomeHeader.tsx
+++ b/apps/client/src/widgets/home/HomeHeader/HomeHeader.tsx
@@ -18,7 +18,6 @@ export const HomeHeader = ({ isBlack }: HomeHeaderProps) => {
         <div className="flex items-center gap-4">
           <Logo isBlack={isBlack} />
         </div>
-        <div className="h-8 w-8 rounded-full bg-gray-300"></div>
       </div>
     </header>
   );

--- a/apps/client/src/widgets/home/WorkspaceModal/WorkspaceModal.tsx
+++ b/apps/client/src/widgets/home/WorkspaceModal/WorkspaceModal.tsx
@@ -26,7 +26,7 @@ export const WorkspaceModal = () => {
     <ModalConfirm isOpen={isOpen}>
       <div className="text-center">
         <div className="mb-10 flex flex-col items-center justify-center gap-3 text-center">
-          <img src="./images/booduck_modal.png" width={100} height={100} />
+          <img src="/images/booduck_modal.png" width={100} height={100} />
           <p className="text-semibold-lg whitespace-pre-line text-gray-500">{modalContent}</p>
         </div>
 


### PR DESCRIPTION
## 🔗 Linked Issue (#178)

## 🙋‍ Summary (요약) 
- 이미지 경로 수정
- 안 쓰는 프로필이미지 요소 삭제

## 😎 Description (변경사항)
### 이미지 경로 수정
```tsx
<img src="/images/boolock_logo.png" width={32} height={32} alt="Boolock Logo" />
```
- 경로를 상대경로에서 절대경로로 변경해주니 잘 동작했습니다 ㅎㅎ

### 안 쓰는 프로필이미지 요소 삭제
![image](https://github.com/user-attachments/assets/d6084744-1472-4cc5-be68-ea2c950aa673)

- 저희 우측 상단에 안 쓰는 프로필 이미지 요소 삭제했습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
