### PR TITLE
[#176] html generator 적용 에러

### DIFF
--- a/apps/client/src/core/styleFlyout.ts
+++ b/apps/client/src/core/styleFlyout.ts
@@ -25,6 +25,7 @@ export default class StyleFlyout extends FixedFlyout {
   inputElement: HTMLInputElement | null = null;
   buttonElement: HTMLButtonElement | null = null;
 
+  // CSS 클래스 Flyout 초기 생성
   init(targetWorkspace: Blockly.WorkspaceSvg): void {
     super.init(targetWorkspace);
     const toolbox = this.targetWorkspace.getToolbox() as TabbedToolbox;
@@ -120,6 +121,7 @@ export default class StyleFlyout extends FixedFlyout {
       );
     };
 
+    // Tooltip 이벤트 등록
     questionImageElement.addEventListener('mouseenter', showTooltip);
     questionImageElement.addEventListener('mouseleave', hideTooltip);
 
@@ -143,6 +145,7 @@ export default class StyleFlyout extends FixedFlyout {
     this.show(cssStyleToolboxConfig.contents);
   }
 
+  // 마우스 우클릭 시 컨텍스트 메뉴
   registerCustomContextMenu() {
     const menuId = 'deleteBlock';
 
@@ -151,6 +154,7 @@ export default class StyleFlyout extends FixedFlyout {
       return;
     }
 
+    // 컨텍스트 메뉴 삭제 옵션 정보
     const deleteOption = {
       id: menuId,
       scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
@@ -164,7 +168,7 @@ export default class StyleFlyout extends FixedFlyout {
         return isInCssStyleToolboxConfig && scope.block.isDeletable() ? 'enabled' : 'hidden';
       },
 
-      callback: (scope: any, _e: PointerEvent) => {
+      callback: (scope: any) => {
         const block = scope.block;
         const blockType = block.type;
 
@@ -184,9 +188,10 @@ export default class StyleFlyout extends FixedFlyout {
       },
     };
 
+    // 블록 삭제 옵션 등록
     Blockly.ContextMenuRegistry.registry.register(deleteOption);
 
-    // 툴팁 닫기 이벤트 추가
+    // 컨텍스트 메뉴 외부 영역 클릭 시 닫기 이벤트 추가
     document.addEventListener('click', (event) => {
       const contextMenu = document.querySelector('.blocklyContextMenu');
       if (contextMenu && !contextMenu.contains(event.target as Node)) {
@@ -195,24 +200,29 @@ export default class StyleFlyout extends FixedFlyout {
     });
   }
 
+  // 새로운 스타일 블록 생성
   createStyleBlock() {
     const inputValue = this.inputElement?.value;
+    // 클래스명 입력값이 없을 경우 에러 메시지 출력
     if (!inputValue) {
       return toast.error('클래스명을 입력해주세요.');
     }
 
+    // 클래스명 유효성 검사
     if (!validateClassNameStart(inputValue)) {
       return toast.error('클래스명 첫 글자는 영문자, 밑줄(_), 하이픈(-)만 가능해요');
     } else if (!validateClassNameBody(inputValue)) {
       return toast.error('클래스명은 영문자, 밑줄(_), 하이픈(-), 숫자만 포함해주세요');
     }
 
+    // 클래스명 중복 검사
     const existingBlocks: TBlock[] = cssStyleToolboxConfig!.contents || [];
     const isBlockAlreadyAdded = existingBlocks.some((block) => block.type === inputValue);
     if (isBlockAlreadyAdded) {
       return toast.error(`"${inputValue}" 입력한 클래스명 블록은 이미 존재합니다.`);
     }
 
+    // 새롭게 생성되는 CSS 클래스 블록 정보
     if (!Blockly.Blocks[inputValue!]) {
       useCssPropsStore.getState().addNewCssClass(inputValue);
       Blockly.Blocks[inputValue!] = {
@@ -220,14 +230,14 @@ export default class StyleFlyout extends FixedFlyout {
           this.appendDummyInput().appendField(
             new CustomFieldLabelSerializable(inputValue!),
             'CLASS'
-          ); // 입력된 이름 반영
+          );
           this.setOutput(true);
           this.setStyle(`defaultBlockCss`);
         },
       };
     }
 
-    // 기존 블록에 새 블록 추가
+    // 기존 블록들이 있는 cssStyleToolboxConfig.ts에 새 블록 추가
     cssStyleToolboxConfig!.contents = [
       ...existingBlocks,
       { kind: 'block', type: inputValue, enabled: true },

--- a/apps/client/src/shared/blockly/htmlCodeGenerator.ts
+++ b/apps/client/src/shared/blockly/htmlCodeGenerator.ts
@@ -56,6 +56,12 @@ htmlCodeGenerator.forBlock[addPreviousTypeName('br')] = function () {
 
 // 연속적인 코드 블록을 생성하기 위해 블록 연결을 처리하도록 코드 생성을 커스터마이즈
 htmlCodeGenerator.scrub_ = function (block, code, thisOnly) {
+  // 최상위 블록 (getRootBlock: Blockly의 블록 트리 탐색 함수)
+  const topBlock = block.getRootBlock();
+  // 최상위 블록이 html 블록이 아니면 빈 문자열 반환
+  if (topBlock.type !== addPreviousTypeName('html')) {
+    return '';
+  }
   // 다음 블록 찾기
   const nextBlock = block.nextConnection && block.nextConnection.targetBlock();
   // 다음 블록의 코드를 추가

--- a/apps/client/src/shared/blockly/htmlCodeGenerator.ts
+++ b/apps/client/src/shared/blockly/htmlCodeGenerator.ts
@@ -71,6 +71,20 @@ htmlCodeGenerator.scrub_ = function (block, code, thisOnly) {
   return code;
 };
 
+// 전체 코드 생성 함수
+export const generateFullCode = (workspace: Blockly.Workspace) => {
+  const topBlockList = workspace.getTopBlocks(true);
+  const codeList = topBlockList.map((block) => {
+    try {
+      return htmlCodeGenerator.blockToCode(block) || '';
+    } catch (e) {
+      console.error(`블록 ${block.type} 처리 중 오류 발생:`, e);
+      return '';
+    }
+  });
+  return codeList.join('\n');
+};
+
 transferTagBlockToCode(addPreviousTypeName('html'));
 transferTagBlockToCode(addPreviousTypeName('body'));
 

--- a/apps/client/src/shared/blockly/htmlCodeGenerator.ts
+++ b/apps/client/src/shared/blockly/htmlCodeGenerator.ts
@@ -74,14 +74,22 @@ htmlCodeGenerator.scrub_ = function (block, code, thisOnly) {
 // 전체 코드 생성 함수
 export const generateFullCode = (workspace: Blockly.Workspace) => {
   const topBlockList = workspace.getTopBlocks(true);
-  const codeList = topBlockList.map((block) => {
-    try {
-      return htmlCodeGenerator.blockToCode(block) || '';
-    } catch (e) {
-      console.error(`블록 ${block.type} 처리 중 오류 발생:`, e);
-      return '';
-    }
-  });
+
+  // HTML 블록 내부에 포함된 블록만 처리
+  const codeList = topBlockList
+    .filter((block) => {
+      const rootBlock = block.getRootBlock();
+      return rootBlock.type === addPreviousTypeName('html');
+    })
+    .map((block) => {
+      try {
+        return htmlCodeGenerator.blockToCode(block) || '';
+      } catch (e) {
+        console.error(`블록 ${block.type} 처리 중 오류 발생:`, e);
+        return '';
+      }
+    });
+
   return codeList.join('\n');
 };
 

--- a/apps/client/src/shared/blockly/index.ts
+++ b/apps/client/src/shared/blockly/index.ts
@@ -9,3 +9,4 @@ export { initTheme } from './initTheme';
 export { tabToolboxConfig } from './tabConfig';
 export { createCssClassBlock } from './createCssClassBlock';
 export { cssCodeGenerator } from './cssCodeGenerator';
+export { generateFullCode } from './htmlCodeGenerator';

--- a/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
@@ -7,7 +7,7 @@ import {
   blockContents,
   cssCodeGenerator,
   defineBlocks,
-  htmlCodeGenerator,
+  generateFullCode,
   htmlTagToolboxConfig,
   initTheme,
   initializeBlocks,
@@ -55,6 +55,7 @@ export const WorkspaceContent = () => {
   const { totalCssPropertyObj } = useCssPropsStore();
   const { workspace, setWorkspace, canvasInfo } = useWorkspaceStore();
   const { setIsBlockChanged } = useWorkspaceChangeStatusStore();
+
   useEffect(() => {
     const newWorkspace = Blockly.inject('blocklyDiv', {
       plugins: {
@@ -78,20 +79,18 @@ export const WorkspaceContent = () => {
     });
 
     (newWorkspace.getToolbox() as TabbedToolbox).setConfig(tabToolboxConfig);
-
     initializeBlocks(newWorkspace);
-
     newWorkspace.clearUndo();
+
     // workspace 변화 감지해 자동 변환
     const handleAutoConversion = (event: Blockly.Events.Abstract) => {
       if (
         event.type === Blockly.Events.BLOCK_CREATE ||
         event.type === Blockly.Events.BLOCK_MOVE ||
-        event.type === Blockly.Events.BLOCK_DRAG ||
         event.type === Blockly.Events.BLOCK_CHANGE ||
         event.type === Blockly.Events.BLOCK_DELETE
       ) {
-        const code = htmlCodeGenerator.workspaceToCode(newWorkspace);
+        const code = generateFullCode(newWorkspace);
         setHtmlCode(code);
         setIsBlockChanged(true);
       }


### PR DESCRIPTION
## 🔗 Linked Issue (이슈)

## 🙋‍ Summary (요약) 

- html generator 할 때 잘 안먹힘 - class 블록에 특정 오류 발생 추정
- 블록이 body를 벗어나도 프리뷰에 계속 보임

## 😎 Description (변경사항)

- html 블록에 포함된 것만 처리하게 변경하였습니다.

```
  // 최상위 블록 (getRootBlock: Blockly의 블록 트리 탐색 함수)
  const topBlock = block.getRootBlock();
  // 최상위 블록이 html 블록이 아니면 빈 문자열 반환
  if (topBlock.type !== addPreviousTypeName('html')) {
    return '';
  }
```


- 또한 클래스 블록에 대해 변경처리를 위해 workspace내의 모든 블럭을 기반으로 코드 재생성하는 함수를 만들었습니다.

```js
// 전체 코드 생성 함수
export const generateFullCode = (workspace: Blockly.Workspace) => {
  const topBlockList = workspace.getTopBlocks(true);
  const codeList = topBlockList.map((block) => {
    try {
      return htmlCodeGenerator.blockToCode(block) || '';
    } catch (e) {
      console.error(`블록 ${block.type} 처리 중 오류 발생:`, e);
      return '';
    }
  });
  return codeList.join('\n');
};
```


- before

![html 외에 처리된다](https://github.com/user-attachments/assets/5ce54118-2f0c-4516-a94a-543ac43ace9c)


- after

![after](https://github.com/user-attachments/assets/730cf81f-1da8-4005-8031-7f9b7bd8ff4a)



## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
- 지금 블록이 html 내부가 아니라 밖으로가면 빈 값으로 처리되는 부분이 있는데, 이 부분은 코드 하이라이팅 구현에서 함께 처리하겠습니다. 
