### PR TITLE
[#187] 폰트 선택 기능 추가

### DIFF
--- a/apps/client/src/shared/utils/cssCategoryList.ts
+++ b/apps/client/src/shared/utils/cssCategoryList.ts
@@ -74,6 +74,25 @@ export const cssCategoryList: TCssCategoryList = [
     category: '타이포그래피',
     items: [
       {
+        label: 'font-family',
+        type: 'select',
+        option: [
+          'Noto Sans KR',
+          'Noto Serif KR',
+          'Nanum Gothic',
+          'Gaegu',
+          'IBM Plex Sans KR',
+          'Gothic A1',
+        ],
+        description: '폰트를 지정합니다.',
+      },
+      {
+        label: 'font-weight',
+        type: 'select',
+        option: ['300', '400', '700'],
+        description: '폰트의 굵기를 설정합니다. 숫자가 커질수록 굵어집니다.',
+      },
+      {
         label: 'line-height',
         type: 'input',
         description: '줄 높이를 지정합니다.',

--- a/apps/client/src/widgets/workspace/PreviewBox/PreviewBox.tsx
+++ b/apps/client/src/widgets/workspace/PreviewBox/PreviewBox.tsx
@@ -21,10 +21,15 @@ export const PreviewBox = ({ htmlCode, cssCode }: PreviewBoxProps) => {
   const [activeTab, setActiveTab] = useState<'preview' | 'html' | 'css'>('preview');
   const { isResetCssChecked } = useResetCssStore();
 
+  const googleFontsLinksCode = `
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Gaegu:wght@300;400;700&family=Gothic+A1:wght@300;400;700&family=IBM+Plex+Sans+KR:wght@300;400;700&family=Nanum+Gothic:wght@400;700&family=Noto+Sans+KR:wght@100..900&family=Noto+Serif+KR:wght@200..900&display=swap" rel="stylesheet" />
+  `;
   const finalCssCode = isResetCssChecked ? `${resetCss}\n${cssCode}` : cssCode;
   const styleCode = `<style> * { box-sizing : border-box; margin : 0; padding : 0; } html, head, body { width : 100%; height : 100%; } ${finalCssCode}</style>`;
   const indexOfHead = htmlCode.indexOf('</head>');
-  const totalCode = `${htmlCode.slice(0, indexOfHead)}${styleCode}${htmlCode.slice(indexOfHead)}`;
+  const totalCode = `${htmlCode.slice(0, indexOfHead)}${googleFontsLinksCode}${styleCode}${htmlCode.slice(indexOfHead)}`;
 
   // TODO: 상수 분리한 후 재사용성 높이기
   /* eslint-disable */


### PR DESCRIPTION
## 🔗 Linked Issue (이슈)
#187 

## 🙋‍ Summary (요약) 
- 폰트 선택 기능 추가

## 😎 Description (변경사항)
<!-- 작업 내용 설명 -->
### 폰트 선택 기능 추가

![bandicam2024-12-0118-44-17-240-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/a8bb5998-24d6-4654-9a93-2f48686f16b3)

총 6개의 폰트 google font에서 한글 폰트 중 weight가 3개 이상인(Nanum Gothic 제외) 폰트를 선정했습니다. 굵기는 300, 400, 700 중 선택할 수 있도록 옵션을 제공했습니다.

```typescript
  'Noto Sans KR',
  'Noto Serif KR',
  'Nanum Gothic',
  'Gaegu',
  'IBM Plex Sans KR',
  'Gothic A1',
```

previewBox에서 iframe head에 구글 폰트를 사용할 때 필요한 link를 넣어주었습니다.
```typescript
  const googleFontsLinksCode = `
    <link rel="preconnect" href="https://fonts.googleapis.com" />
    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
    <link href="https://fonts.googleapis.com/css2?family=Gaegu:wght@300;400;700&family=Gothic+A1:wght@300;400;700&family=IBM+Plex+Sans+KR:wght@300;400;700&family=Nanum+Gothic:wght@400;700&family=Noto+Sans+KR:wght@100..900&family=Noto+Serif+KR:wght@200..900&display=swap" rel="stylesheet" />
  `;
  const finalCssCode = isResetCssChecked ? `${resetCss}\n${cssCode}` : cssCode;
  const styleCode = `<style> * { box-sizing : border-box; margin : 0; padding : 0; } html, head, body { width : 100%; height : 100%; } ${finalCssCode}</style>`;
  const indexOfHead = htmlCode.indexOf('</head>');
  const totalCode = `${htmlCode.slice(0, indexOfHead)}${googleFontsLinksCode}${styleCode}${htmlCode.slice(indexOfHead)}`;
```

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
나눔 고딕은 300이 없어서 300을 선택해도 400처럼 나오는데 많이 사용한느 폰트기도 하고 빼기에는 폰트 선택지가 너무 없는 것 같아서 추가했습니다.