### PR TITLE
flyout 크기 고정

### DIFF
--- a/apps/client/src/core/fixedFlyout.ts
+++ b/apps/client/src/core/fixedFlyout.ts
@@ -64,6 +64,18 @@ export default class FixedFlyout extends Blockly.VerticalFlyout {
   }
 
   /**
+   * Flyout을 크기 비율을 반환하는 함수입니다.
+   *
+   * @description
+   * 기본적으로 workspace의 비율을 따라가지만 고정하기 위해 1을 빈환합니다.
+   *
+   * @override
+   */
+  override getFlyoutScale(): number {
+    return 1;
+  }
+
+  /**
    * 새로운 블록이 추가될 때 위치를 지정합니다.
    *
    * @description


### PR DESCRIPTION
## 🔗 Linked Issue (이슈)
#133 

## 🙋‍ Summary (요약) 
- flyout 크기 고정

## 😎 Description (변경사항)
### flyout 크기 고정
![bandicam2024-12-0202-53-49-826-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0b93bb65-6301-4069-8cef-0d0fcb6b0f96)
- workspace와 flyout 사이에 연결되어 있던 zoom 비율을 끊었습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
아직 img 태그랑 a 태그가 없는 상태라서 문제가 없는데 ... 두 태그가 생기면 flyout 좌우로 스크롤 되도록 만들겠습니다...?