### PR TITLE
[#202] 워크스페이스 목록에서 샘플 이미지 깨지는 문제 해결, 미리보기 캡처 시 css 적용 안되는 문제 해결 및 자잘한 버그 해결

### DIFF
--- a/apps/client/src/app/index.css
+++ b/apps/client/src/app/index.css
@@ -210,3 +210,91 @@ input[type='color']::-webkit-color-swatch-wrapper {
   @apply text-gray-400;
   padding: 0 6px 0 12px;
 }
+
+.reset-css {
+  html,
+  body,
+  div,
+  span,
+  header,
+  section,
+  nav,
+  main,
+  article,
+  footer,
+  p,
+  strong,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  small,
+  br,
+  em,
+  i,
+  blockquote,
+  hr,
+  input,
+  button,
+  form,
+  option,
+  textarea,
+  select,
+  fieldset,
+  legend,
+  label,
+  td,
+  tr,
+  th,
+  caption,
+  table,
+  ul,
+  ol,
+  li,
+  a {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+
+  article,
+  header,
+  section,
+  nav,
+  main,
+  footer {
+    display: block;
+  }
+
+  body {
+    line-height: 1;
+  }
+
+  ol,
+  ul {
+    list-style: none;
+  }
+
+  blockquote,
+  q {
+    quotes: none;
+  }
+
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: '';
+    content: none;
+  }
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+}

--- a/apps/client/src/core/styleFlyout.ts
+++ b/apps/client/src/core/styleFlyout.ts
@@ -74,6 +74,7 @@ export default class StyleFlyout extends FixedFlyout {
       class: 'resetCssCheckbox',
     });
     resetCssCheckboxElement.checked = useResetCssStore.getState().isResetCssChecked;
+    useWorkspaceChangeStatusStore.getState().setIsCssChanged(true);
     resetCssCheckboxElement.addEventListener('change', () => {
       useResetCssStore.getState().toggleResetCss();
     });
@@ -241,6 +242,7 @@ export default class StyleFlyout extends FixedFlyout {
 
     if (!Blockly.Blocks[createClassType!]) {
       useCssPropsStore.getState().addNewCssClass(createClassType);
+      useWorkspaceChangeStatusStore.getState().setIsBlockChanged(true);
       Blockly.Blocks[createClassType!] = {
         init: function () {
           this.appendDummyInput().appendField(

--- a/apps/client/src/core/styleFlyout.ts
+++ b/apps/client/src/core/styleFlyout.ts
@@ -198,7 +198,7 @@ export default class StyleFlyout extends FixedFlyout {
 
         const flyout = (Blockly.getMainWorkspace() as any).getToolbox().getFlyout();
         flyout.show(cssStyleToolboxConfig.contents);
-        toast.success(`"${blockType}" 클래스 블록이 삭제되었습니다.`);
+        toast.success(`"${blockType.replace('CSS_', '')}" 클래스 블록이 삭제되었습니다.`);
       },
     };
 

--- a/apps/client/src/entities/workspace/SaveButton/SaveButton.tsx
+++ b/apps/client/src/entities/workspace/SaveButton/SaveButton.tsx
@@ -3,17 +3,18 @@ import * as Blockly from 'blockly/core';
 import { useCssPropsStore, useResetCssStore, useWorkspaceStore } from '@/shared/store';
 
 import { Spinner } from '@/shared/ui';
+import { capturePreview } from '@/shared/utils';
 import { cssStyleToolboxConfig } from '@/shared/blockly';
-import html2canvas from 'html2canvas';
 import toast from 'react-hot-toast';
 import { useParams } from 'react-router-dom';
 import { useSaveWorkspace } from '@/shared/hooks';
+import { useState } from 'react';
 
 /**
  *
  * @description
  * Workspace 상태를 저장하는 버튼입니다.
- * 저장 항목 : css 속성, 캔버스 블록 상태, css class 블록, css 리셋 여부
+ * 저장 항목 : css 속성, 캔버스 블록 상태, css class 블록, css 리셋 여부, 미리보기 썸네일
  */
 export const SaveButton = () => {
   const workspaceId = useParams().workspaceId as string;
@@ -21,33 +22,12 @@ export const SaveButton = () => {
   const { totalCssPropertyObj } = useCssPropsStore();
   const { workspace } = useWorkspaceStore();
   const { isResetCssChecked } = useResetCssStore();
-
-  const ERROR_MESSAGE = {
-    SELECT_PREVIEW_TAB: '미리보기 탭을 선택해주세요.',
-    FAIL_TO_SAVE: '저장에 실패했습니다.',
-  };
-
-  const capturePreview = async () => {
-    const previewIframe = document.querySelector('iframe');
-    if (!previewIframe) {
-      throw new Error(ERROR_MESSAGE.SELECT_PREVIEW_TAB);
-    }
-    const previewContent = previewIframe.contentWindow!.document.body;
-    const preview = await html2canvas(previewContent, {});
-    const blob = await new Promise<Blob | null>((resolve) => preview.toBlob(resolve, 'image/png'));
-    if (!blob) {
-      throw new Error(ERROR_MESSAGE.FAIL_TO_SAVE);
-    }
-    const thumbnail = new File([blob], 'thumbnail.png', { type: 'image/png' });
-    if (!thumbnail) {
-      throw new Error(ERROR_MESSAGE.FAIL_TO_SAVE);
-    }
-    return thumbnail;
-  };
+  const [isCapture, setIsCapture] = useState<boolean>(false);
 
   const handleClick = async () => {
     try {
       const canvas = Blockly.serialization.workspaces.save(workspace!) as any;
+      setIsCapture(true);
       const thumbnail = await capturePreview();
       saveWorkspace({
         totalCssPropertyObj,
@@ -56,24 +36,29 @@ export const SaveButton = () => {
         cssResetStatus: isResetCssChecked,
         thumbnail,
       });
+      setIsCapture(false);
     } catch (error) {
       if (error instanceof Error) {
         toast.error(error.message);
       }
+    } finally {
+      setIsCapture(false);
     }
   };
 
   return (
-    <button
-      onClick={handleClick}
-      className="text-bold-rg w-16 rounded-[30px] bg-green-500 py-2 text-green-100 hover:border hover:border-green-500 hover:bg-green-100 hover:text-green-500"
-      disabled={isPending}
-    >
-      {isPending ? (
-        <Spinner width={4} height={4} backgroundColor="gray200" foregroundColor="grayWhite" />
-      ) : (
-        <p>저장</p>
-      )}
-    </button>
+    <>
+      <button
+        onClick={handleClick}
+        className="text-bold-rg w-16 rounded-[30px] bg-green-500 py-2 text-green-100 hover:border hover:border-green-500 hover:bg-green-100 hover:text-green-500"
+        disabled={isPending}
+      >
+        {isPending || isCapture ? (
+          <Spinner width={4} height={4} backgroundColor="gray200" foregroundColor="grayWhite" />
+        ) : (
+          <p>저장</p>
+        )}
+      </button>
+    </>
   );
 };

--- a/apps/client/src/entities/workspace/WorkspaceNameInput/WorkspaceNameInput.tsx
+++ b/apps/client/src/entities/workspace/WorkspaceNameInput/WorkspaceNameInput.tsx
@@ -1,9 +1,9 @@
-import { FocusEventHandler, KeyboardEventHandler } from 'react';
-import { useUpdateWorkspaceName, workspaceKeys } from '@/shared/hooks';
+import { FocusEventHandler, KeyboardEventHandler, useEffect, useState } from 'react';
+
 import { Spinner } from '@/shared/ui';
-import { TGetWorkspaceResponse } from '@/shared/types';
 import { useParams } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
+import { useUpdateWorkspaceName } from '@/shared/hooks';
+import { useWorkspaceStore } from '@/shared/store';
 
 /**
  * @description
@@ -12,11 +12,16 @@ import { useQueryClient } from '@tanstack/react-query';
 export const WorkspaceNameInput = () => {
   const { workspaceId } = useParams() as { workspaceId: string };
   const { mutate, isPending } = useUpdateWorkspaceName();
-  const queryClient = useQueryClient();
-  const workspaceData = queryClient.getQueryData<TGetWorkspaceResponse>(
-    workspaceKeys.detail(workspaceId)
-  );
-  const name = workspaceData?.workspaceDto?.name || '워크스페이스 이름';
+  const { name } = useWorkspaceStore();
+  const [editableWorkspaceName, setEditableWorkspaceName] = useState<string>('');
+
+  useEffect(() => {
+    setEditableWorkspaceName(name);
+  }, [name]);
+
+  const handleOnChange = (value: string) => {
+    setEditableWorkspaceName(value);
+  };
 
   const handleBlur: FocusEventHandler<HTMLInputElement> = (
     event: React.FocusEvent<HTMLInputElement>
@@ -46,12 +51,14 @@ export const WorkspaceNameInput = () => {
     <>
       <div className="relative flex items-center">
         <input
-          placeholder={name === '' ? '워크스페이스 이름' : name}
+          placeholder="이름을 입력해주세요"
           className="placeholder:text-semibold-rg w-[272px] rounded-md border border-green-500 px-3 py-1 placeholder:text-gray-100 focus:outline-none"
           onBlur={handleBlur}
           onKeyDown={handleEnter}
           maxLength={20}
           disabled={isPending}
+          value={editableWorkspaceName}
+          onChange={(e) => handleOnChange(e.target.value)}
         />
         {isPending && (
           <div className="absolute right-5">

--- a/apps/client/src/shared/code-highlighter/components/CodeViewer.tsx
+++ b/apps/client/src/shared/code-highlighter/components/CodeViewer.tsx
@@ -1,8 +1,8 @@
-import styles from '../styles/CodeViewer.module.css';
-import { parseHighlightCss } from '../utils/parseHighlightCss';
-import { parseHighlightHtml } from '../utils/parseHighlightHtml';
 import { CodeContent } from './CodeContent';
 import { LineNumbers } from './LineNumbers';
+import { parseHighlightCss } from '../utils/parseHighlightCss';
+import { parseHighlightHtml } from '../utils/parseHighlightHtml';
+import styles from '../styles/CodeViewer.module.css';
 
 type CodeViewerProps = {
   code: string;
@@ -21,15 +21,11 @@ export const CodeViewer = ({
   selectedBlockLength,
   selectedBlockType,
 }: CodeViewerProps) => {
-  console.log('type', type);
   const parsedCode =
     type === 'html'
       ? parseHighlightHtml(code, styles, selectedBlockType!)
       : parseHighlightCss(code, styles, selectedBlockType!);
   const codeLineList = parsedCode.split('\n').filter((line) => line.trim() !== '');
-
-  console.log('parsedCode', parsedCode);
-  console.log('codeLineList', codeLineList);
 
   return (
     <div className={`${styles.viewer} ${theme === 'dark' ? styles.dark : styles.light}`}>

--- a/apps/client/src/shared/hooks/queries/useCreateWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useCreateWorkspace.ts
@@ -1,10 +1,11 @@
+import { createUserId, getUserId } from '@/shared/utils';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { TCreatedWorkspaceDto } from '@/shared/types';
 import { WorkspaceApi } from '@/shared/api';
 import toast from 'react-hot-toast';
 import { useLoadingStore } from '@/shared/store';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { getUserId, createUserId } from '@/shared/utils';
 import { workspaceKeys } from '@/shared/hooks';
 
 export const useCreateWorkspace = (isSample = false) => {
@@ -24,8 +25,7 @@ export const useCreateWorkspace = (isSample = false) => {
         navigate(`/workspace/${newWorkspace.newWorkspaceId}`);
       }
     },
-    onError: (error) => {
-      console.error(error);
+    onError: () => {
       toast.error('워크스페이스 생성 실패');
     },
     onSettled: () => {

--- a/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
@@ -19,9 +19,10 @@ export const useGetWorkspace = (workspaceId: string) => {
   const userId = getUserId() || createUserId();
   const { initCssPropertyObj } = useCssPropsStore();
   const { initClassBlockList } = useClassBlockStore();
-  const { setCanvasInfo } = useWorkspaceStore();
+  const { setCanvasInfo, setName } = useWorkspaceStore();
   const { resetChangedStatusState } = useWorkspaceChangeStatusStore();
   const { setIsResetCssChecked } = useResetCssStore();
+
   const { data, isPending, isError } = useQuery({
     queryKey: workspaceKeys.detail(workspaceId),
     queryFn: () => {
@@ -45,6 +46,7 @@ export const useGetWorkspace = (workspaceId: string) => {
     if (!data.workspaceDto) {
       return;
     }
+    setName(data.workspaceDto.name);
     Object.keys(data.workspaceDto.totalCssPropertyObj).forEach((className) => {
       createCssClassBlock(className);
     });

--- a/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
@@ -1,3 +1,5 @@
+import { createCssClassBlock, cssStyleToolboxConfig } from '@/shared/blockly';
+import { createUserId, getUserId, removeCssClassNamePrefix } from '@/shared/utils';
 import {
   useClassBlockStore,
   useCssPropsStore,
@@ -7,12 +9,10 @@ import {
 } from '@/shared/store';
 
 import { WorkspaceApi } from '@/shared/api';
-import { createUserId, getUserId, removeCssClassNamePrefix } from '@/shared/utils';
 import toast from 'react-hot-toast';
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { workspaceKeys } from '@/shared/hooks';
-import { createCssClassBlock, cssStyleToolboxConfig } from '@/shared/blockly';
 
 export const useGetWorkspace = (workspaceId: string) => {
   const workspaceApi = WorkspaceApi();
@@ -45,6 +45,9 @@ export const useGetWorkspace = (workspaceId: string) => {
     if (!data.workspaceDto) {
       return;
     }
+    Object.keys(data.workspaceDto.totalCssPropertyObj).forEach((className) => {
+      createCssClassBlock(className);
+    });
 
     initCssPropertyObj(data.workspaceDto.totalCssPropertyObj);
     initClassBlockList(
@@ -57,9 +60,6 @@ export const useGetWorkspace = (workspaceId: string) => {
       ? JSON.parse(data.workspaceDto.classBlockList)
       : [];
     setIsResetCssChecked(data.workspaceDto.isCssReset);
-    Object.keys(data.workspaceDto.totalCssPropertyObj).forEach((className) => {
-      createCssClassBlock(className);
-    });
   }, [isError, data]);
   return { data, isPending, isError };
 };

--- a/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
@@ -1,18 +1,16 @@
 import { TCanvas, TTotalCssPropertyObj } from '@/shared/types/workspaceType';
 import { createUserId, getUserId } from '@/shared/utils';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { TBlock } from '@/shared/types';
 import { WorkspaceApi } from '@/shared/api';
 import toast from 'react-hot-toast';
+import { useMutation } from '@tanstack/react-query';
 import { useWorkspaceChangeStatusStore } from '@/shared/store';
-import { workspaceKeys } from '../query-key/workspaceKeys';
 
 export const useSaveWorkspace = (workspaceId: string) => {
   const workspaceApi = WorkspaceApi();
   const userId = getUserId() || createUserId();
   const { resetChangedStatusState } = useWorkspaceChangeStatusStore();
-  const queryClient = useQueryClient();
   const { mutate, isPending } = useMutation({
     mutationFn: ({
       totalCssPropertyObj,
@@ -39,7 +37,6 @@ export const useSaveWorkspace = (workspaceId: string) => {
     },
     onSuccess: () => {
       resetChangedStatusState();
-      queryClient.invalidateQueries({ queryKey: workspaceKeys.detail(workspaceId) });
       toast.success('성공적으로 저장되었습니다.');
     },
     onError: () => {

--- a/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
@@ -1,9 +1,9 @@
 import { TCanvas, TTotalCssPropertyObj } from '@/shared/types/workspaceType';
+import { createUserId, getUserId } from '@/shared/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { TBlock } from '@/shared/types';
 import { WorkspaceApi } from '@/shared/api';
-import { createUserId, getUserId } from '@/shared/utils';
 import toast from 'react-hot-toast';
 import { useWorkspaceChangeStatusStore } from '@/shared/store';
 import { workspaceKeys } from '../query-key/workspaceKeys';
@@ -27,15 +27,6 @@ export const useSaveWorkspace = (workspaceId: string) => {
       cssResetStatus: boolean;
       thumbnail: File;
     }) => {
-      /*
-       * return Promise.all([
-       *   workspaceApi.saveWorkspaceCssProperty(userId, workspaceId, totalCssPropertyObj),
-       *   workspaceApi.saveWorkspaceCanvas(userId, workspaceId, canvas),
-       *   workspaceApi.saveWorkspaceClassBlockList(userId, workspaceId, classBlockList),
-       *   workspaceApi.saveWorkspaceCssResetStatus(userId, workspaceId, cssResetStatus),
-       * ]);
-       */
-
       return workspaceApi.saveWorkspace(
         userId,
         workspaceId,

--- a/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useSaveWorkspace.ts
@@ -1,15 +1,17 @@
 import { TCanvas, TTotalCssPropertyObj } from '@/shared/types/workspaceType';
 import { createUserId, getUserId } from '@/shared/utils';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { TBlock } from '@/shared/types';
 import { WorkspaceApi } from '@/shared/api';
 import toast from 'react-hot-toast';
-import { useMutation } from '@tanstack/react-query';
 import { useWorkspaceChangeStatusStore } from '@/shared/store';
+import { workspaceKeys } from '@/shared/hooks/query-key/workspaceKeys';
 
 export const useSaveWorkspace = (workspaceId: string) => {
   const workspaceApi = WorkspaceApi();
   const userId = getUserId() || createUserId();
+  const queryClient = useQueryClient();
   const { resetChangedStatusState } = useWorkspaceChangeStatusStore();
   const { mutate, isPending } = useMutation({
     mutationFn: ({
@@ -37,6 +39,7 @@ export const useSaveWorkspace = (workspaceId: string) => {
     },
     onSuccess: () => {
       resetChangedStatusState();
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.list() });
       toast.success('성공적으로 저장되었습니다.');
     },
     onError: () => {

--- a/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
+++ b/apps/client/src/shared/hooks/queries/useUpdateWorkspaceName.ts
@@ -1,28 +1,23 @@
+import { createUserId, getUserId } from '@/shared/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { TWorkspaceDto } from '@/shared/types';
 import { WorkspaceApi } from '@/shared/api';
-import { createUserId, getUserId } from '@/shared/utils';
 import toast from 'react-hot-toast';
+import { useWorkspaceStore } from '@/shared/store';
 import { workspaceKeys } from '@/shared/hooks';
 
 export const useUpdateWorkspaceName = () => {
   const queryClient = useQueryClient();
   const workspaceApi = WorkspaceApi();
   const userId = getUserId() || createUserId();
-
+  const { setName } = useWorkspaceStore();
   const { mutate, isPending } = useMutation({
     mutationFn: ({ workspaceId, newName }: { workspaceId: string; newName: string }) => {
       return workspaceApi.updateWorkspaceName(userId, workspaceId, newName);
     },
     onSuccess: (data) => {
       toast.success('워크스페이스 이름이 변경되었습니다.');
-      queryClient.setQueryData(workspaceKeys.detail(data.workspaceId), (oldData: TWorkspaceDto) => {
-        return {
-          ...oldData,
-          name: data.name,
-        };
-      });
+      setName(data.name);
       queryClient.invalidateQueries({ queryKey: workspaceKeys.list() });
     },
     onError: () => {

--- a/apps/client/src/shared/store/useClassBlockStore.ts
+++ b/apps/client/src/shared/store/useClassBlockStore.ts
@@ -18,7 +18,7 @@ export const useClassBlockStore = create<TClassBlock>((set, get) => ({
   },
   findClassBlock: (classBlockName: string) => {
     const state = get();
-    return state.classBlockList.includes(classBlockName);
+    return state.classBlockList.includes(removeCssClassNamePrefix(classBlockName));
   },
   removeClassBlock: (classBlockName: string) => {
     set((state) => ({

--- a/apps/client/src/shared/store/useClassBlockStore.ts
+++ b/apps/client/src/shared/store/useClassBlockStore.ts
@@ -22,7 +22,9 @@ export const useClassBlockStore = create<TClassBlock>((set, get) => ({
   },
   removeClassBlock: (classBlockName: string) => {
     set((state) => ({
-      classBlockList: state.classBlockList.filter((name) => name !== classBlockName),
+      classBlockList: state.classBlockList.filter(
+        (name) => name !== removeCssClassNamePrefix(classBlockName)
+      ),
     }));
   },
   initClassBlockList: (classList: string[]) => {

--- a/apps/client/src/shared/store/useWorkspaceStore.ts
+++ b/apps/client/src/shared/store/useWorkspaceStore.ts
@@ -1,19 +1,24 @@
-import { create } from 'zustand';
 import * as Blockly from 'blockly/core';
+
+import { create } from 'zustand';
 
 type TWorkspace = {
   workspace: Blockly.WorkspaceSvg | null;
   canvasInfo: string;
+  name: string;
 
   setWorkspace: (newWorkspace: Blockly.WorkspaceSvg | null) => void;
   setCanvasInfo: (blockInfo: string) => void;
+  setName: (name: string) => void;
 };
 
 export const useWorkspaceStore = create<TWorkspace>((set) => ({
   workspace: null,
   canvasInfo: '',
+  name: '워크스페이스 이름',
   setWorkspace: (newWorkspace: Blockly.WorkspaceSvg | null) => {
     set({ workspace: newWorkspace });
   },
   setCanvasInfo: (blockInfo: string) => set(() => ({ canvasInfo: blockInfo })),
+  setName: (name: string) => set(() => ({ name: name })),
 }));

--- a/apps/client/src/shared/utils/capturePreview.ts
+++ b/apps/client/src/shared/utils/capturePreview.ts
@@ -17,6 +17,13 @@ export const capturePreview = async () => {
   if (!previewDocument) {
     throw new Error(ERROR_MESSAGE.FAIL_TO_SAVE);
   }
+
+  /**
+   * iframe의 body 태그를 div 태그로 변경하여 html2canvas로 캡쳐할 수 있도록 설정
+   */
+  const previewHtml = previewDocument.documentElement.outerHTML
+    .replace('<body', '<div style="width: 100%; height: 100%;"')
+    .replace('</body>', '</div>');
   const div = document.createElement('div'); // iframe의 내용을 담을 div 생성
   if (isResetCssChecked) {
     div.classList.add('reset-css');
@@ -27,20 +34,18 @@ export const capturePreview = async () => {
      * 그래서 해당 문제를 해결하기 위해 기존 css 클래스들에 대한 특이성을 높이기 위해
      * .reset-css 클래스를 부모 클래스로 설정하여 특이성 문제를 해결
      */
-    const previewHtml = previewDocument?.documentElement.outerHTML
-      .replace('<style>', '<style>.reset-css {')
-      .replace('</style>', '} </style>');
 
-    div.innerHTML = previewHtml as Element['outerHTML'];
+    div.innerHTML = previewHtml
+      .replace('<style>', '<style>.reset-css {')
+      .replace('</style>', '} </style>') as Element['outerHTML'];
   } else {
-    div.innerHTML = previewDocument?.documentElement.outerHTML || '';
+    div.innerHTML = previewHtml || '';
   }
 
   /*
    * div를 화면 밖에서 렌더링하도록 설정 (화면에 보이지 않도록)
    * z-index를 -1로 설정하여 화면에 보이지 않도록 설정
    */
-
   div.style.position = 'absolute';
   div.style.top = '-9999px';
   div.style.zIndex = '-1';

--- a/apps/client/src/shared/utils/capturePreview.ts
+++ b/apps/client/src/shared/utils/capturePreview.ts
@@ -18,7 +18,6 @@ export const capturePreview = async () => {
     throw new Error(ERROR_MESSAGE.FAIL_TO_SAVE);
   }
   const div = document.createElement('div'); // iframe의 내용을 담을 div 생성
-  console.log(previewDocument.documentElement.outerHTML);
   if (isResetCssChecked) {
     div.classList.add('reset-css');
 

--- a/apps/client/src/shared/utils/capturePreview.ts
+++ b/apps/client/src/shared/utils/capturePreview.ts
@@ -1,0 +1,56 @@
+import html2canvas from 'html2canvas';
+import { useResetCssStore } from '@/shared/store';
+
+const ERROR_MESSAGE = {
+  SELECT_PREVIEW_TAB: '미리보기 탭을 선택해주세요.',
+  FAIL_TO_SAVE: '저장에 실패했습니다.',
+};
+
+export const capturePreview = async () => {
+  const isResetCssChecked = useResetCssStore.getState().isResetCssChecked;
+
+  const previewIframe = document.querySelector('iframe');
+  if (!previewIframe) {
+    throw new Error(ERROR_MESSAGE.SELECT_PREVIEW_TAB);
+  }
+  const previewDocument = previewIframe?.contentDocument || previewIframe?.contentWindow?.document;
+  if (!previewDocument) {
+    throw new Error(ERROR_MESSAGE.FAIL_TO_SAVE);
+  }
+  const div = document.createElement('div'); // iframe의 내용을 담을 div 생성
+  console.log(previewDocument.documentElement.outerHTML);
+  if (isResetCssChecked) {
+    div.classList.add('reset-css');
+
+    /**
+     * 만약 reset css를 적용한 경우, reset-css 클래스를 추가하여 reset css 적용
+     * 하지만 reset-css 클래스 사용 시 css 특이성 문제로 인해 기존 css 클래스들이적용되지 않는 경우가 발생함
+     * 그래서 해당 문제를 해결하기 위해 기존 css 클래스들에 대한 특이성을 높이기 위해
+     * .reset-css 클래스를 부모 클래스로 설정하여 특이성 문제를 해결
+     */
+    const previewHtml = previewDocument?.documentElement.outerHTML
+      .replace('<style>', '<style>.reset-css {')
+      .replace('</style>', '} </style>');
+
+    div.innerHTML = previewHtml as Element['outerHTML'];
+  } else {
+    div.innerHTML = previewDocument?.documentElement.outerHTML || '';
+  }
+
+  /*
+   * div를 화면 밖에서 렌더링하도록 설정 (화면에 보이지 않도록)
+   * z-index를 -1로 설정하여 화면에 보이지 않도록 설정
+   */
+
+  div.style.position = 'absolute';
+  div.style.top = '-9999px';
+  div.style.zIndex = '-1';
+  div.style.width = '800px';
+  div.style.height = '800px';
+  document.body.appendChild(div);
+  const canvas = await html2canvas(div, { useCORS: true, logging: true, scale: 2, width: 800 });
+  document.body.removeChild(div);
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/webp'));
+  const thumbnail = new File([blob as Blob], 'thumbnail.webp', { type: 'image/webp' });
+  return thumbnail;
+};

--- a/apps/client/src/shared/utils/index.ts
+++ b/apps/client/src/shared/utils/index.ts
@@ -13,3 +13,4 @@ export {
 export { debounce } from './debounce';
 export { cssCategoryList } from './cssCategoryList';
 export { hasField } from './typeGuard';
+export { capturePreview } from './capturePreview';

--- a/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
@@ -97,7 +97,6 @@ export const WorkspaceContent = () => {
 
     // workspace 변화 감지해 자동 변환
     const handleAutoConversion = (event: Blockly.Events.Abstract) => {
-      console.log(event.type);
       if (
         event.type === Blockly.Events.BLOCK_CREATE ||
         event.type === Blockly.Events.BLOCK_MOVE ||

--- a/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
@@ -5,18 +5,17 @@ import * as Blockly from 'blockly/core';
 import { CssPropsSelectBox, PreviewBox } from '@/widgets';
 import {
   blockContents,
+  calculateBlockLength,
   cssCodeGenerator,
   defineBlocks,
-  removeBlockIdFromCode,
-  generateFullCodeWithBlockId,
-  calculateBlockLength,
   findBlockStartLine,
+  generateFullCodeWithBlockId,
   htmlTagToolboxConfig,
   initTheme,
   initializeBlocks,
+  removeBlockIdFromCode,
   tabToolboxConfig,
 } from '@/shared/blockly';
-
 import {
   useClassBlockStore,
   useCssPropsStore,
@@ -98,6 +97,7 @@ export const WorkspaceContent = () => {
 
     // workspace 변화 감지해 자동 변환
     const handleAutoConversion = (event: Blockly.Events.Abstract) => {
+      console.log(event.type);
       if (
         event.type === Blockly.Events.BLOCK_CREATE ||
         event.type === Blockly.Events.BLOCK_MOVE ||
@@ -111,13 +111,14 @@ export const WorkspaceContent = () => {
         const codeWithNoId = removeBlockIdFromCode(codeWithId);
 
         setHtmlCode(codeWithNoId);
-
-        if (isBlockLoadingFinish.current) {
-          setIsBlockChanged(true);
-        }
       }
 
-      if (event.type === Blockly.Events.VIEWPORT_CHANGE && isBlockLoadingFinish.current) {
+      if (
+        event.type === Blockly.Events.VIEWPORT_CHANGE ||
+        event.type === Blockly.Events.BLOCK_DRAG ||
+        event.type === Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE ||
+        (event.type === Blockly.Events.BLOCK_DELETE && isBlockLoadingFinish.current)
+      ) {
         setIsBlockChanged(true);
       }
 
@@ -133,7 +134,6 @@ export const WorkspaceContent = () => {
       }
 
       const block = newWorkspace.getBlockById(event.blockId || '');
-      console.log('block type', block?.type);
 
       setSelectedBlockType(
         block && block.type.startsWith('CSS_') ? block.type.replace(/^CSS_/, '') : null

--- a/apps/client/src/widgets/workspace/css/CssPropsSelectBoxHeader/CssPropsSelectBoxHeader.tsx
+++ b/apps/client/src/widgets/workspace/css/CssPropsSelectBoxHeader/CssPropsSelectBoxHeader.tsx
@@ -1,7 +1,7 @@
 import { Select, TOption } from '@/shared/ui';
+import { addPrefixToCssClassName, removeCssClassNamePrefix } from '@/shared/utils';
 import { useClassBlockStore, useCssPropsStore } from '@/shared/store';
 import { useEffect, useState } from 'react';
-import { addPrefixToCssClassName } from '@/shared/utils';
 
 /**
  *
@@ -30,7 +30,7 @@ export const CssPropsSelectBoxHeader = () => {
       <p className="text-semibold-md text-gray-black truncate">CSS 클래스 속성 편집</p>
       <Select
         options={selectOptions}
-        value={currentCssClassName}
+        value={removeCssClassNamePrefix(currentCssClassName)}
         onChange={(selected: string) => setCurrentCssClassName(addPrefixToCssClassName(selected))}
         placeholder="클래스를 선택해주세요"
       />

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,7 +15,6 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "mongoose": "^8.8.0",
-    "sharp": "^0.33.5",
     "tunnel-ssh": "^5.1.2"
   },
   "devDependencies": {

--- a/apps/server/src/services/workspaceService.ts
+++ b/apps/server/src/services/workspaceService.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+
 import 'dotenv/config';
 
 import { S3, Upload } from '@/config/s3';
@@ -153,8 +154,7 @@ export const WorkspaceService = () => {
     try {
       const webpThumbnail = await sharp(thumbnail.buffer)
         .resize({
-          width: 528,
-          height: 360,
+          width: 800,
           fit: 'inside',
           background: { r: 255, g: 255, b: 255, alpha: 1 },
         })
@@ -213,8 +213,7 @@ export const WorkspaceService = () => {
     // 이미지 리사이징 및 webp 변환
     const webpThumbnail = await sharp(imageBuffer)
       .resize({
-        width: 528,
-        height: 360,
+        width: 800,
         fit: 'inside',
         background: { r: 255, g: 255, b: 255, alpha: 1 },
       })

--- a/apps/server/src/services/workspaceService.ts
+++ b/apps/server/src/services/workspaceService.ts
@@ -8,7 +8,6 @@ import { TTotalCssPropertyObj, TWorkspace } from '@/types/workspaceType';
 import { Workspace } from '@/models/workspaceModel';
 import { generateCssList } from '@/services/utils/generateCssList';
 import { generateTotalCssPropertyObj } from '@/services/utils/generateTotalCssPropertyObj';
-import sharp from 'sharp';
 
 export const WorkspaceService = () => {
   const createWorkspace = async (userId: string) => {
@@ -28,10 +27,6 @@ export const WorkspaceService = () => {
     const newWorkspaceId = crypto.randomUUID();
 
     try {
-      const sampleThumbnailResponse = await fetch(sampleWorkspace.thumbnail!);
-      const imageBuffer = Buffer.from(await sampleThumbnailResponse.arrayBuffer());
-      const thumbnailUrl = await uploadThumbnailImage(userId, newWorkspaceId, imageBuffer);
-
       const clonedWorkspaceData = {
         workspace_id: newWorkspaceId,
         user_id: userId,
@@ -40,7 +35,8 @@ export const WorkspaceService = () => {
         css_list: sampleWorkspace.css_list,
         class_block_list: sampleWorkspace.class_block_list,
         is_css_reset: sampleWorkspace.is_css_reset,
-        thumbnail: thumbnailUrl,
+        thumbnail:
+          'https://kr.object.ncloudstorage.com/boolock-storage/thumbnail/default/sample_thumbnail.webp',
         updated_at: new Date(),
       };
 
@@ -152,25 +148,18 @@ export const WorkspaceService = () => {
     const session = await Workspace.startSession();
     session.startTransaction();
     try {
-      const webpThumbnail = await sharp(thumbnail.buffer)
-        .resize({
-          width: 800,
-          fit: 'inside',
-          background: { r: 255, g: 255, b: 255, alpha: 1 },
-        })
-        .webp()
-        .toBuffer();
       const upload = new Upload({
         client: S3,
         params: {
           Bucket: process.env.S3_BUCKET_NAME,
           Key: `thumbnail/${userId}/${workspaceId}.webp`,
           ACL: 'public-read',
-          Body: webpThumbnail,
+          Body: thumbnail.buffer,
           ContentType: 'image/webp',
         },
       });
       const uploadResult = await upload.done();
+      console.log(uploadResult);
       if (!uploadResult) {
         throw new Error('Failed to upload thumbnail');
       }
@@ -203,41 +192,6 @@ export const WorkspaceService = () => {
     } finally {
       session.endSession();
     }
-  };
-
-  const uploadThumbnailImage = async (
-    userId: string,
-    workspaceId: string,
-    imageBuffer: Buffer
-  ): Promise<string> => {
-    // 이미지 리사이징 및 webp 변환
-    const webpThumbnail = await sharp(imageBuffer)
-      .resize({
-        width: 800,
-        fit: 'inside',
-        background: { r: 255, g: 255, b: 255, alpha: 1 },
-      })
-      .webp()
-      .toBuffer();
-
-    // S3 업로드
-    const upload = new Upload({
-      client: S3,
-      params: {
-        Bucket: process.env.S3_BUCKET_NAME,
-        Key: `thumbnail/${userId}/${workspaceId}.webp`,
-        ACL: 'public-read',
-        Body: webpThumbnail,
-        ContentType: 'image/webp',
-      },
-    });
-
-    const uploadResult = await upload.done();
-    if (!uploadResult) {
-      throw new Error('Failed to upload thumbnail');
-    }
-
-    return uploadResult.Location as string;
   };
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       mongoose:
         specifier: ^8.8.0
         version: 8.8.1
-      sharp:
-        specifier: ^0.33.5
-        version: 0.33.5
       tunnel-ssh:
         specifier: ^5.1.2
         version: 5.1.2
@@ -593,9 +590,6 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@emnapi/runtime@1.3.1':
-    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
-
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -931,111 +925,6 @@ packages:
   '@humanwhocodes/retry@0.4.1':
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
-
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2215,13 +2104,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
-
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -2406,10 +2288,6 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
-  detect-libc@2.0.3:
-    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
-    engines: {node: '>=8'}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2946,9 +2824,6 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-arrayish@0.3.2:
-    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
 
   is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
@@ -3939,10 +3814,6 @@ packages:
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3964,9 +3835,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-swizzle@0.2.2:
-    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
@@ -5341,11 +5209,6 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@emnapi/runtime@1.3.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -5538,81 +5401,6 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.1': {}
-
-  '@img/sharp-darwin-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
-    optional: true
-
-  '@img/sharp-linux-s390x@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-    optional: true
-
-  '@img/sharp-wasm32@0.33.5':
-    dependencies:
-      '@emnapi/runtime': 1.3.1
-    optional: true
-
-  '@img/sharp-win32-ia32@0.33.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.33.5':
-    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -7098,16 +6886,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -7267,8 +7045,6 @@ snapshots:
   dequal@2.0.3: {}
 
   destroy@1.2.0: {}
-
-  detect-libc@2.0.3: {}
 
   didyoumean@1.2.2: {}
 
@@ -7963,8 +7739,6 @@ snapshots:
       get-intrinsic: 1.2.4
 
   is-arrayish@0.2.1: {}
-
-  is-arrayish@0.3.2: {}
 
   is-async-function@2.0.0:
     dependencies:
@@ -8920,32 +8694,6 @@ snapshots:
 
   shallowequal@1.1.0: {}
 
-  sharp@0.33.5:
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.3
-      semver: 7.6.3
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -8964,10 +8712,6 @@ snapshots:
   sift@17.1.3: {}
 
   signal-exit@4.1.0: {}
-
-  simple-swizzle@0.2.2:
-    dependencies:
-      is-arrayish: 0.3.2
 
   simple-update-notifier@2.0.0:
     dependencies:


### PR DESCRIPTION
## 🔗 
#202 
#207
#208
#209
#210


## 🙋‍ Summary (요약) 
- 워크스페이스 썸네일 이미지 깨짐 문제 해결
- 워크스페이스 썸네일 캡처 시 CSS 적용 안되는 문제 해결
- 워크스페이스 이름 변경 혹은 저장 시 워크스페이스 상태가 초기화 되는 문제 해결
- css 클래스 블록 클릭 혹은 select태그로 css 클래스 블록을 선택해도 선택되지 않는 문제 해결

## 😎 Description (변경사항)
### 워크스페이스 썸네일 이미지 깨짐 문제 해결
- 이미지의 width와 height를 설정해줬는데 height를 기준으로 사진이 리사이징 되어 비정상적인 크기의 이미지가 생성되는 문제가 있었음

**문제의 이미지**
![image](https://github.com/user-attachments/assets/96e5d980-7ff8-43c2-a2e3-80fd0a081321)
-리사이징할 너비와 높이를 모두 설정하는 것이 아닌 너비만 설정하여 문제해결 -> 800px로 고정
  - 이유 : 워크스페이스 썸네일 기준 약 3배의 업스케일링이 적용되어 800px로 고정했습니다.

**해결 후 썸네일**
![image](https://github.com/user-attachments/assets/63a3983a-79de-4786-8559-78eee89e902f)

### 미리보기 캡처 시 css가 적용 안되는 문제
- iframe의 document만 캡처할 경우 `html2canvas`의 한계인지 폰트 및 다른 css들이 적용되지 않는 문제가 발생

**문제의 썸네일**
![image](https://github.com/user-attachments/assets/0599d69d-bad4-4556-b83a-40f48a8995d5)

**해결 방법**
1. 직접 canvas를 생성하고 해당 canvas에 iframe의 document의 모든 요소를 그리는 방식
    - 너무 비효율적이고 CSS를 모두 적용하기에는 무리가 있었음
    - 또한 flex나 grid는 직접 path 값을 계산해야되는 문제가 있었음
2. div 요소를 만든 뒤 해당 요소의 innerhtml를 조작하여 iframe document 요소를 삽입하고 body의 자식 요소로 만들어 캡처 후 remove하는 방식
    - 직접 DOM 조작이라는 문제가 있지만 canvas에다가 직접 그리는 방식에 비해 html2canvas 라이브러리를 활용하여 캡처를 할 수 있다는 장점이 있었음
    - 한정된 시간 속에서 방법2가 매우 효율적이라 선택
 
**방법 2로 문제 해결하면서 있었던 일들**
- reset css 코드가 `<style></style>`에 적용되어 전체 웹사이트의 css가 초기화되는 문제 발생
  -  style 태그는 html 문서 어디에든 위치할 수 있고 전역적으로 사용이 가능해서 해당 문제 발생
-`reset-css` 라는 클래스를 만들어 해결함
  - index.css에 `.reset-css` 선언 및 css 적용

- `reset-css`를 적용하니 블록에 적용한 CSS 클래스보다 우선적으로 css가 적용되는 문제 발생
```css
.reset-css {
  html,
  body {
    //css 코드
  }
```
  - .reset-css { html, body } 와 같은 방식으로 선언이 되어 있어 특정성이 (0,1,1)임
  - 그냥 블록에 적용된 CSS 클래스는 .title, .header 와 같이 선언이 되어 있어 특정성이 (0,1,0)이었음
  - 그래서 reset-css에 적용된 CSS가 우선적으로 적용이 되었음
- iframe document `<style></style>` 태그 안에 .reset-css { 기존 css 클래스들 }를 추가하는 방식으로 해결
```ts
  if (isResetCssChecked) {
    div.classList.add('reset-css');

    /**
     * 만약 reset css를 적용한 경우, reset-css 클래스를 추가하여 reset css 적용
     * 하지만 reset-css 클래스 사용 시 css 특이성 문제로 인해 기존 css 클래스들이적용되지 않는 경우가 발생함
     * 그래서 해당 문제를 해결하기 위해 기존 css 클래스들에 대한 특이성을 높이기 위해
     * .reset-css 클래스를 부모 클래스로 설정하여 특이성 문제를 해결
     */

    div.innerHTML = previewHtml
      .replace('<style>', '<style>.reset-css {')
      .replace('</style>', '} </style>') as Element['outerHTML'];
  }
```
- iframe body에만 스타일을 주었을 때 썸네일을 캡처할 수 없는 문제 해결
  -  div에 iframe.document.documentElement.outerHtml을 삽입하면 html, head, body 태그는 전부 제외됨
  -  만약, body 태그의 자식 요소가 없다면 div에 삽입할 때 아무런 요소가 들어가지 않게 됨
  - div에 요소가 없으니 width, height가 존재하지 않아 캡처가 되지 않았음
- div에 삽입하기 전  iframe document의 body 태그를 div로 변경 후 style="width:100%; height:100%"를 주어 해결

### 워크스페이스 이름 변경, 저장 시 워크스페이스 상태가 초기화 되는 문제
**기존 방식**
```ts
  if (isResetCssChecked) {
    div.classList.add('reset-css');

    /**
     * 만약 reset css를 적용한 경우, reset-css 클래스를 추가하여 reset css 적용
     * 하지만 reset-css 클래스 사용 시 css 특이성 문제로 인해 기존 css 클래스들이적용되지 않는 경우가 발생함
     * 그래서 해당 문제를 해결하기 위해 기존 css 클래스들에 대한 특이성을 높이기 위해
     * .reset-css 클래스를 부모 클래스로 설정하여 특이성 문제를 해결
     */

    div.innerHTML = previewHtml
      .replace('<style>', '<style>.reset-css {')
      .replace('</style>', '} </style>') as Element['outerHTML'];
  }
```
```ts
onSuccess: () => {
      resetChangedStatusState();
      queryClient.invalidateQueries({ queryKey: workspaceKeys.detail(workspaceId) });
      toast.success('성공적으로 저장되었습니다.');
    },
```
- 다음과 같이 불필요하게 캐시 데이터를 조작하는 과정을 없앴습니다.
- 이름 변경의 경우, input 창에서 워크스페이스 이름을 바로 변경할 수 있게 전역 변수를 사용하는 방식으로 변경하면서 해결할 수 있었습니다.

### sharp 패키지 삭제
- 썸네일을 생성할 때 blob 객체에서 webp로 파일 변환이 바로 가능했기에 클라이언트에서 webp로 이미지 생성 후 서버로 전달하는 방식이 되어 서버에서 이미지 webp 변환 시 필요했던 패키지를 더이상 사용하지 않게 되어 삭제했습니다.

### 자잘한 버그 수정
- 워크스페이스 생성 시 변경사항을 감지하지 못하는 문제
- class 블록 클릭 시 select 창에서 블록을 선택하여 css 클래스가 선택되지 않는 문제
- class 블록 삭제 시 삭제가 반영되지 않는 문제 등등을 해결했습니다.


## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
- reset css를 적용안하고 썸네일 캡처를 진행해도 tailwind css의 자체 reset css가 적용되는 문제가 있지만 해결하지 못한 상태입니다.
