### PR TITLE
[HOTFIX] 워크스페이스 처음 생성시 에러 해결

### DIFF
--- a/apps/client/src/widgets/workspace/CoachMark/CoachMark.tsx
+++ b/apps/client/src/widgets/workspace/CoachMark/CoachMark.tsx
@@ -31,6 +31,10 @@ export const CoachMark = () => {
 
   useEffect(() => {
     const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    if (!workspace) {
+      return;
+    }
+
     const toolbox = workspace.getToolbox() as TabbedToolbox;
 
     if (!toolbox) return;


### PR DESCRIPTION
## 🔗 Linked Issue #218 

## 🙋‍ Summary (요약) 
- 워크스페이스 처음 생성시 에러 해결

## 😎 Description (변경사항)
### 워크스페이스 처음 생성시 에러 해결
![hotfix_1204](https://github.com/user-attachments/assets/64400b38-f00d-449b-9fd0-73a08e9d96fb)


## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
워크스페이스 내 툴박스 렌더링 되기 전에 CoachMark에서 관련 메서드를 호출해서 발생한 에러였습니다.
```typescript
  useEffect(() => {
    const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
    if (!workspace) { // 예외처리
      return;
    }

    const toolbox = workspace.getToolbox() as TabbedToolbox;

    if (!toolbox) return;

    switch (currentStep) {
      case 0:
        toolbox.clickTab('html');
        break;
      case 1:
        toolbox.clickTab('css');
        break;
      case 2:
        toolbox.clickTab('html');
    }
    ...
  }, [currentStep, toolboxDiv]);
``` 

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
- 화면 가로가 작은 경우 코치마크 4단계일 때 겹치는 문제 해결해야 합니다 #220 
