### PR TITLE
[#223] 코드 내보내기 버튼 추가

### DIFF
--- a/apps/client/src/entities/index.ts
+++ b/apps/client/src/entities/index.ts
@@ -19,3 +19,4 @@ export { ImageTagModalHeader } from './workspace/ImageTagModalHeader/ImageTagMod
 export { ImageTagModalImg } from './workspace/ImageTagModalImg/ImageTagModalImg';
 export { ImageTagModalButton } from './workspace/ImageTagModalButton/ImageTagModalButton';
 export { ImageTagModalListItem } from './workspace/ImageTagModalListItem/ImageTagModalListItem';
+export { CodeExportButton } from './workspace/CodeExportButton/CodeExportButton';

--- a/apps/client/src/entities/workspace/CodeExportButton/CodeExportButton.stories.tsx
+++ b/apps/client/src/entities/workspace/CodeExportButton/CodeExportButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { CodeExportButton } from './CodeExportButton';
+
+const meta: Meta<typeof CodeExportButton> = {
+  title: 'entities/workspace/CodeExportButton',
+  component: CodeExportButton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CodeExportButton>;
+
+export const Default: Story = {};

--- a/apps/client/src/entities/workspace/CodeExportButton/CodeExportButton.tsx
+++ b/apps/client/src/entities/workspace/CodeExportButton/CodeExportButton.tsx
@@ -1,0 +1,35 @@
+import { Spinner } from '@/shared/ui';
+import { exportPreviewHtml } from '@/shared/utils';
+import toast from 'react-hot-toast';
+import { useState } from 'react';
+
+export const CodeExportButton = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleClick = () => {
+    try {
+      setIsLoading(true);
+      exportPreviewHtml();
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="text-bold-rg rounded-full border border-gray-100 px-4 py-2 text-gray-400 transition-colors ease-in-out hover:border-gray-300 hover:bg-gray-50 hover:text-gray-300"
+      disabled={isLoading}
+    >
+      {isLoading ? (
+        <Spinner width={4} height={4} foregroundColor="grayWhite" backgroundColor="gray200" />
+      ) : (
+        <p>코드 내보내기</p>
+      )}
+    </button>
+  );
+};

--- a/apps/client/src/entities/workspace/ImageTagModalList/ImageTagModalList.tsx
+++ b/apps/client/src/entities/workspace/ImageTagModalList/ImageTagModalList.tsx
@@ -1,9 +1,10 @@
 import { useDeleteImage, usePostImage } from '@/shared/hooks';
-import { useImageModalStore } from '@/shared/store';
-import { useRef } from 'react';
-import toast from 'react-hot-toast';
-import { useParams } from 'react-router-dom';
+
 import { ImageTagModalListItem } from '../ImageTagModalListItem/ImageTagModalListItem';
+import toast from 'react-hot-toast';
+import { useImageModalStore } from '@/shared/store';
+import { useParams } from 'react-router-dom';
+import { useRef } from 'react';
 
 type ImageListProps = {
   tagSrc: string;
@@ -43,7 +44,6 @@ export const ImageTagModalList = ({ tagSrc, onSetTagSrc }: ImageListProps) => {
 
           const filename = file.name.replace(/\.(png|jpeg|jpg|svg)$/i, '');
           const invalidChars = /[\\/:*?"<>|]/;
-          console.log(filename);
 
           if (invalidChars.test(filename)) {
             return handleShowError(

--- a/apps/client/src/shared/store/index.ts
+++ b/apps/client/src/shared/store/index.ts
@@ -8,3 +8,4 @@ export { useBlocklyWorkspaceStore } from './useBlocklyWorkspaceStore';
 export { useResetCssStore } from './useResetCssStore';
 export { useWorkspaceStore } from './useWorkspaceStore';
 export { useImageModalStore } from './useImageModalStore';
+export { useIframeStore } from './useIframeStore';

--- a/apps/client/src/shared/store/useIframeStore.ts
+++ b/apps/client/src/shared/store/useIframeStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+type TIframe = {
+  iframeRef: React.RefObject<HTMLIFrameElement> | null;
+  setIframeRef: (ref: React.RefObject<HTMLIFrameElement>) => void;
+};
+
+export const useIframeStore = create<TIframe>((set) => ({
+  iframeRef: null,
+  setIframeRef: (ref) => set({ iframeRef: ref }),
+}));

--- a/apps/client/src/shared/utils/capturePreview.ts
+++ b/apps/client/src/shared/utils/capturePreview.ts
@@ -1,21 +1,19 @@
-import html2canvas from 'html2canvas';
-import { useResetCssStore } from '@/shared/store';
+import { useIframeStore, useResetCssStore } from '@/shared/store';
 
-const ERROR_MESSAGE = {
-  SELECT_PREVIEW_TAB: '미리보기 탭을 선택해주세요.',
-  FAIL_TO_SAVE: '저장에 실패했습니다.',
-};
+import { IFRAME_ERROR_MESSAGE } from '@/shared/utils';
+import html2canvas from 'html2canvas';
 
 export const capturePreview = async () => {
   const isResetCssChecked = useResetCssStore.getState().isResetCssChecked;
 
-  const previewIframe = document.querySelector('iframe');
+  const previewIframe = useIframeStore.getState().iframeRef?.current;
+
   if (!previewIframe) {
-    throw new Error(ERROR_MESSAGE.SELECT_PREVIEW_TAB);
+    throw new Error(IFRAME_ERROR_MESSAGE.SELECT_PREVIEW_TAB);
   }
   const previewDocument = previewIframe?.contentDocument || previewIframe?.contentWindow?.document;
   if (!previewDocument) {
-    throw new Error(ERROR_MESSAGE.FAIL_TO_SAVE);
+    throw new Error(IFRAME_ERROR_MESSAGE.FAIL_TO_SAVE);
   }
 
   /**
@@ -34,7 +32,6 @@ export const capturePreview = async () => {
      * 그래서 해당 문제를 해결하기 위해 기존 css 클래스들에 대한 특이성을 높이기 위해
      * .reset-css 클래스를 부모 클래스로 설정하여 특이성 문제를 해결
      */
-
     div.innerHTML = previewHtml
       .replace('<style>', '<style>.reset-css {')
       .replace('</style>', '} </style>') as Element['outerHTML'];

--- a/apps/client/src/shared/utils/exportPreviewHtml.ts
+++ b/apps/client/src/shared/utils/exportPreviewHtml.ts
@@ -1,0 +1,30 @@
+import { useIframeStore, useWorkspaceStore } from '@/shared/store';
+
+import { IFRAME_ERROR_MESSAGE } from '@/shared/utils';
+
+export const exportPreviewHtml = () => {
+  const previewIframe = useIframeStore.getState().iframeRef?.current;
+  const workspaceName = useWorkspaceStore.getState().name;
+
+  if (!previewIframe) {
+    throw new Error(IFRAME_ERROR_MESSAGE.SELECT_PREVIEW_TAB);
+  }
+
+  const previewDocument = previewIframe?.contentDocument || previewIframe?.contentWindow?.document;
+  if (!previewDocument) {
+    throw new Error(IFRAME_ERROR_MESSAGE.FAIL_TO_SAVE);
+  }
+
+  const previewHtml = previewDocument.documentElement.outerHTML;
+
+  const blob = new Blob([previewHtml], { type: 'text/html' });
+
+  const url = URL.createObjectURL(blob);
+
+  const downloadLink = document.createElement('a');
+  downloadLink.href = url;
+  downloadLink.download = `${workspaceName}.html`;
+  downloadLink.click();
+  URL.revokeObjectURL(url);
+  return false;
+};

--- a/apps/client/src/shared/utils/iframeErrorMessage.ts
+++ b/apps/client/src/shared/utils/iframeErrorMessage.ts
@@ -1,0 +1,4 @@
+export const IFRAME_ERROR_MESSAGE = {
+  SELECT_PREVIEW_TAB: '미리보기 탭을 선택해주세요.',
+  FAIL_TO_SAVE: '저장에 실패했습니다.',
+};

--- a/apps/client/src/shared/utils/index.ts
+++ b/apps/client/src/shared/utils/index.ts
@@ -15,3 +15,5 @@ export { cssCategoryList } from './cssCategoryList';
 export { hasField } from './typeGuard';
 export { capturePreview } from './capturePreview';
 export { coachMarkContent } from './coachMarkContent';
+export { IFRAME_ERROR_MESSAGE } from './iframeErrorMessage';
+export { exportPreviewHtml } from './exportPreviewHtml';

--- a/apps/client/src/widgets/workspace/PreviewBox/PreviewBox.tsx
+++ b/apps/client/src/widgets/workspace/PreviewBox/PreviewBox.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
-import { useResetCssStore } from '@/shared/store';
-import { resetCss } from '@/shared/utils/resetCss';
-import CopyIcon from '@/shared/assets/code_copy.svg?react';
-import toast from 'react-hot-toast';
+import { useEffect, useRef, useState } from 'react';
+import { useIframeStore, useResetCssStore } from '@/shared/store';
+
 import { CodeViewer } from '@/shared/code-highlighter';
+import CopyIcon from '@/shared/assets/code_copy.svg?react';
+import { resetCss } from '@/shared/utils/resetCss';
+import toast from 'react-hot-toast';
 import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
 
 type PreviewBoxProps = {
@@ -29,6 +30,8 @@ export const PreviewBox = ({
   const [activeTab, setActiveTab] = useState<'preview' | 'html' | 'css'>('preview');
   const { isResetCssChecked } = useResetCssStore();
   const { currentStep } = useCoachMarkStore();
+  const { setIframeRef } = useIframeStore();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const googleFontsLinksCode = `
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -40,6 +43,12 @@ export const PreviewBox = ({
   const styleCode = `<style> * { box-sizing : border-box; margin : 0; padding : 0; ::-webkit-scrollbar { width: 8px; } ::-webkit-scrollbar-thumb { background: #cdd9e4; border-radius: 4px; } } html, head, body { width : 100%; height : 100%;  } ${finalCssCode}</style>`;
   const indexOfHead = htmlCode.indexOf('</head>');
   const totalCode = `${htmlCode.slice(0, indexOfHead)}${googleFontsLinksCode}${styleCode}${htmlCode.slice(indexOfHead)}`;
+
+  useEffect(() => {
+    if (iframeRef.current) {
+      setIframeRef(iframeRef);
+    }
+  }, [iframeRef]);
 
   // TODO: 상수 분리한 후 재사용성 높이기
   /* eslint-disable */
@@ -95,6 +104,7 @@ export const PreviewBox = ({
 
         {activeTab === 'preview' && (
           <iframe
+            ref={iframeRef}
             srcDoc={totalCode}
             className="h-full w-full"
             title="Preview"

--- a/apps/client/src/widgets/workspace/WorkspaceHeaderButtons/WorkspaceHeaderButtons.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceHeaderButtons/WorkspaceHeaderButtons.tsx
@@ -1,10 +1,12 @@
-import { RedoButton, SaveButton, UndoButton } from '@/entities';
+import { CodeExportButton, RedoButton, SaveButton, UndoButton } from '@/entities';
+
 import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
 
 export const WorkspaceHeaderButtons = () => {
   const { currentStep } = useCoachMarkStore();
   return (
     <div className={`flex items-center gap-3 ${currentStep === 4 ? 'z-[99999]' : ''}`}>
+      <CodeExportButton />
       <SaveButton />
       <UndoButton />
       <RedoButton />

--- a/apps/server/src/services/workspaceService.ts
+++ b/apps/server/src/services/workspaceService.ts
@@ -1,8 +1,10 @@
 /* eslint-disable camelcase */
 
 import 'dotenv/config';
+
 import { S3, Upload } from '@/config/s3';
 import { TTotalCssPropertyObj, TWorkspace } from '@/types/workspaceType';
+
 import { Workspace } from '@/models/workspaceModel';
 import { generateCssList } from '@/services/utils/generateCssList';
 import { generateTotalCssPropertyObj } from '@/services/utils/generateTotalCssPropertyObj';
@@ -187,7 +189,6 @@ export const WorkspaceService = () => {
         },
       });
       const uploadResult = await upload.done();
-      console.log(uploadResult);
       if (!uploadResult) {
         throw new Error('Failed to upload thumbnail');
       }


### PR DESCRIPTION
## 🔗 #223 

## 🙋‍ Summary (요약) 
- 코드 내보내기 기능 추가
- 코드 내보내기 버튼 추가

## 😎 Description (변경사항)
### iframe 전역 상태화
```ts
import { create } from 'zustand';

type TIframe = {
  iframeRef: React.RefObject<HTMLIFrameElement> | null;
  setIframeRef: (ref: React.RefObject<HTMLIFrameElement>) => void;
};

export const useIframeStore = create<TIframe>((set) => ({
  iframeRef: null,
  setIframeRef: (ref) => set({ iframeRef: ref }),
}));
```
### 코드 내보내기 기능
- iframe document를 그대로 다운 받는 기능 추가
  - 다운로드된 파일이름은 워크스페이스 이름.html 으로 설정

### 코드 내보내기 버튼 추가
- 워크스페이스 header에 추가

![BooLock--Chrome2024-12-0411-24-34-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/78f5d61e-44c3-405b-80a0-1f0fff326b19)


## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
