### PR TITLE
[HOTFIX] CSS 변경사항 감지 로직 변경

### DIFF
--- a/apps/client/src/core/styleFlyout.ts
+++ b/apps/client/src/core/styleFlyout.ts
@@ -74,9 +74,9 @@ export default class StyleFlyout extends FixedFlyout {
       class: 'resetCssCheckbox',
     });
     resetCssCheckboxElement.checked = useResetCssStore.getState().isResetCssChecked;
-    useWorkspaceChangeStatusStore.getState().setIsCssChanged(true);
     resetCssCheckboxElement.addEventListener('change', () => {
       useResetCssStore.getState().toggleResetCss();
+      useWorkspaceChangeStatusStore.getState().setIsCssChanged(true);
     });
 
     const resetCssTextElement = Dom.createElement<HTMLSpanElement>('span', {


### PR DESCRIPTION
## 🔗 #228 

## 🙋‍ Summary (요약) 
- CSS 변경사항 감지 로직 변경

## 😎 Description (변경사항)
### CSS 변경사항 감지로직을 변경했습니다.
- reset css 버튼을 누를 때 감지하도록 변경

**변경 전**
```ts
    resetCssCheckboxElement.checked = useResetCssStore.getState().isResetCssChecked;
    useWorkspaceChangeStatusStore.getState().setIsCssChanged(true);
    resetCssCheckboxElement.addEventListener('change', () => {
      useResetCssStore.getState().toggleResetCss();
    });

```

**변경 후**
```ts
    resetCssCheckboxElement.checked = useResetCssStore.getState().isResetCssChecked;
    resetCssCheckboxElement.addEventListener('change', () => {
      useResetCssStore.getState().toggleResetCss();
      useWorkspaceChangeStatusStore.getState().setIsCssChanged(true);
    });
```

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
