### PR TITLE
[hotfix] 워크스페이스 페이지 조회 시 css클래스 블록을 전부 불러오지 못하는 문제 해결

### DIFF
--- a/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
+++ b/apps/client/src/widgets/workspace/WorkspaceContent/WorkspaceContent.tsx
@@ -7,6 +7,7 @@ import {
   blockContents,
   calculateBlockLength,
   cssCodeGenerator,
+  cssStyleToolboxConfig,
   defineBlocks,
   findBlockStartLine,
   generateFullCodeWithBlockId,
@@ -215,8 +216,15 @@ export const WorkspaceContent = () => {
     if (!workspace || !canvasInfo || canvasInfo.length === 0) {
       return;
     }
-
     Blockly.serialization.workspaces.load(JSON.parse(canvasInfo), workspace);
+    cssStyleToolboxConfig.contents.length = 0;
+    Object.keys(totalCssPropertyObj).forEach((className) => {
+      cssStyleToolboxConfig.contents.push({
+        type: className,
+        kind: 'block',
+        enabled: true,
+      });
+    });
   }, [workspace, canvasInfo]);
 
   useEffect(() => {


### PR DESCRIPTION
## 🔗 #231 

## 🙋‍ Summary (요약) 
- css 클래스 블록을 전부 불러오지 못하는 문제 해결

## 😎 Description (변경사항)
### css 클래스 블록을 load하는 방식을 변경했습니다.
**기존**
```ts
  useEffect(() => {
    if (!workspace || !canvasInfo || canvasInfo.length === 0) {
      return;
    }
    Blockly.serialization.workspaces.load(JSON.parse(canvasInfo), workspace);
  }, [workspace, canvasInfo]);
```

**변경**
```ts
  useEffect(() => {
    if (!workspace || !canvasInfo || canvasInfo.length === 0) {
      return;
    }
    Blockly.serialization.workspaces.load(JSON.parse(canvasInfo), workspace);
    cssStyleToolboxConfig.contents.length = 0;
    Object.keys(totalCssPropertyObj).forEach((className) => {
      cssStyleToolboxConfig.contents.push({
        type: className,
        kind: 'block',
        enabled: true,
      });
    });
  }, [workspace, canvasInfo]);
```
- 클래스 블록을 강제로 초기화해줬습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
