### PR TITLE
🐛 fix: css클래스 삭제 후 똑같은 이름으로 생성 후 css 부여 시 에러 발생하는 버그 수정

### DIFF
--- a/apps/client/src/core/styleFlyout.ts
+++ b/apps/client/src/core/styleFlyout.ts
@@ -240,8 +240,6 @@ export default class StyleFlyout extends FixedFlyout {
 
     // 새롭게 생성되는 CSS 클래스 블록 정보
     if (!Blockly.Blocks[createClassType!]) {
-      useCssPropsStore.getState().addNewCssClass(createClassType);
-      useWorkspaceChangeStatusStore.getState().setIsBlockChanged(true);
       Blockly.Blocks[createClassType!] = {
         init: function () {
           this.appendDummyInput().appendField(
@@ -254,6 +252,8 @@ export default class StyleFlyout extends FixedFlyout {
       };
     }
 
+    useCssPropsStore.getState().addNewCssClass(createClassType);
+    useWorkspaceChangeStatusStore.getState().setIsBlockChanged(true);
     // 기존 블록들이 있는 cssStyleToolboxConfig.ts에 새 블록 추가
     cssStyleToolboxConfig!.contents = [
       ...existingBlocks,


### PR DESCRIPTION
## 🔗 #235 

## 🙋‍ Summary (요약) 
- CSS 클래스 블록 추가 시 CSS 속성 관련 상태 추가 로직 변경

## 😎 Description (변경사항)
### CSS 클래스 블록 추가 시 CSS 속성 관련 상태 추가 로직 변경
- 변경 전
  -  생성하려는 클래스 블록이 기존에 정의 되어 있지 않을 때만 totalPropsStore 객체에 추가했음
```ts
if (!Blockly.Blocks[createClassType!]) {
    useCssPropsStore.getState().addNewCssClass(createClassType);
    useWorkspaceChangeStatusStore.getState().setIsBlockChanged(true);
      Blockly.Blocks[createClassType!] = {
        init: function () {
          this.appendDummyInput().appendField(
            new CustomFieldLabelSerializable(inputValue!),
            'CLASS'
          );
          this.setOutput(true);
          this.setStyle(`defaultBlockCss`);
        },
      };
    }
```
- 변경 후
  - CSS 클래스 블록이 정의 되어 있어도 추가하는 로직으로 변경
```ts
if (!Blockly.Blocks[createClassType!]) {
      Blockly.Blocks[createClassType!] = {
        init: function () {
          this.appendDummyInput().appendField(
            new CustomFieldLabelSerializable(inputValue!),
            'CLASS'
          );
          this.setOutput(true);
          this.setStyle(`defaultBlockCss`);
        },
      };
    }

    useCssPropsStore.getState().addNewCssClass(createClassType);
    useWorkspaceChangeStatusStore.getState().setIsBlockChanged(true);
``` 

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
