### PR TITLE
[HOTFIX] 툴박스 카테고리가 선택안되는 문제 해결

### DIFF
--- a/apps/client/src/core/tabbedToolbox.ts
+++ b/apps/client/src/core/tabbedToolbox.ts
@@ -329,8 +329,41 @@ export default class TabbedToolbox extends Blockly.Toolbox {
     this.contentArea_.innerHTML = '';
   }
 
-  // eslint-disable-next-line no-unused-vars
-  protected onClick_(_e: PointerEvent): void {}
+  protected onClick_(e: PointerEvent): void {
+    const element = e.target as HTMLElement;
+    if (element.tagName === 'INPUT') {
+      return;
+    }
+
+    if (element.textContent === '컨테이너') {
+      this.setSelectedItem(this.getToolboxItems()![0]);
+      return;
+    }
+    if (element.textContent === '텍스트') {
+      this.setSelectedItem(this.getToolboxItems()![1]);
+      return;
+    }
+    if (element.textContent === '폼') {
+      this.setSelectedItem(this.getToolboxItems()![2]);
+      return;
+    }
+    if (element.textContent === '표') {
+      this.setSelectedItem(this.getToolboxItems()![3]);
+      return;
+    }
+    if (element.textContent === '리스트') {
+      this.setSelectedItem(this.getToolboxItems()![4]);
+      return;
+    }
+    if (element.textContent === '링크') {
+      this.setSelectedItem(this.getToolboxItems()![5]);
+      return;
+    }
+    if (element.textContent === '내용') {
+      this.setSelectedItem(this.getToolboxItems()![6]);
+      return;
+    }
+  }
 }
 
 Blockly.Css.register(`


### PR DESCRIPTION
## 🔗 #242 

## 🙋‍ Summary (요약) 
- 툴박스 카테고리가 선택 안되는 문제 해결

## 😎 Description (변경사항)
### 툴박스 카테고리가 선택안되는 문제 해결
- `onClick()` 메서드 수정
```ts
  protected onClick_(e: PointerEvent): void {
    const element = e.target as HTMLElement;
    if (element.tagName === 'INPUT') {
      return;
    }

    if (element.textContent === '컨테이너') {
      this.setSelectedItem(this.getToolboxItems()![0]);
      return;
    }
    if (element.textContent === '텍스트') {
      this.setSelectedItem(this.getToolboxItems()![1]);
      return;
    }
    if (element.textContent === '폼') {
      this.setSelectedItem(this.getToolboxItems()![2]);
      return;
    }
    if (element.textContent === '표') {
      this.setSelectedItem(this.getToolboxItems()![3]);
      return;
    }
    if (element.textContent === '리스트') {
      this.setSelectedItem(this.getToolboxItems()![4]);
      return;
    }
    if (element.textContent === '링크') {
      this.setSelectedItem(this.getToolboxItems()![5]);
      return;
    }
    if (element.textContent === '내용') {
      this.setSelectedItem(this.getToolboxItems()![6]);
      return;
    }
  }
}
```
## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
