### PR TITLE
[#240] 사용자 가이드 하이라이팅 컴포넌트가 모달에서도 하이라이팅

### DIFF
--- a/apps/client/src/entities/workspace/CodeExportButton/CodeExportButton.tsx
+++ b/apps/client/src/entities/workspace/CodeExportButton/CodeExportButton.tsx
@@ -22,7 +22,7 @@ export const CodeExportButton = () => {
   return (
     <button
       onClick={handleClick}
-      className="text-bold-rg rounded-full border border-gray-100 px-4 py-2 text-gray-400 transition-colors ease-in-out hover:border-gray-300 hover:bg-gray-50 hover:text-gray-300"
+      className="text-bold-rg rounded-full border border-gray-100 bg-white px-4 py-2 text-gray-400 transition-colors ease-in-out hover:border-gray-300 hover:bg-gray-50 hover:text-gray-300"
       disabled={isLoading}
     >
       {isLoading ? (

--- a/apps/client/src/pages/Workspacepage/WorkspacePage.tsx
+++ b/apps/client/src/pages/Workspacepage/WorkspacePage.tsx
@@ -6,8 +6,6 @@ import { NotFound } from '@/pages/NotFound/NotFound';
 import { useParams } from 'react-router-dom';
 import { useLayoutEffect, useEffect } from 'react';
 import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
-import * as Blockly from 'blockly/core';
-import TabbedToolbox from '@/core/tabbedToolbox';
 
 /**
  *
@@ -30,32 +28,12 @@ export const WorkspacePage = () => {
   }, []);
 
   useEffect(() => {
-    const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-    if (!workspace) {
-      return;
-    }
+    if (!toolboxDiv) return;
 
-    const toolbox = workspace.getToolbox() as TabbedToolbox;
-
-    if (!toolbox) return;
-
-    switch (currentStep < 5) {
-      case 0:
-        toolbox.clickTab('html');
-        break;
-      case 1:
-        toolbox.clickTab('css');
-        break;
-      case 2:
-        toolbox.clickTab('html');
-    }
-
-    if (toolboxDiv) {
-      if (currentStep <= 1) {
-        toolboxDiv.classList.add('coachMarkHighlight');
-      } else {
-        toolboxDiv.classList.remove('coachMarkHighlight');
-      }
+    if (currentStep <= 1) {
+      toolboxDiv.classList.add('coachMarkHighlight');
+    } else {
+      toolboxDiv.classList.remove('coachMarkHighlight');
     }
   }, [currentStep, toolboxDiv]);
 

--- a/apps/client/src/pages/Workspacepage/WorkspacePage.tsx
+++ b/apps/client/src/pages/Workspacepage/WorkspacePage.tsx
@@ -4,8 +4,10 @@ import { Helmet } from 'react-helmet-async';
 import { Loading } from '@/shared/ui';
 import { NotFound } from '@/pages/NotFound/NotFound';
 import { useParams } from 'react-router-dom';
-import { useLayoutEffect } from 'react';
+import { useLayoutEffect, useEffect } from 'react';
 import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
+import * as Blockly from 'blockly/core';
+import TabbedToolbox from '@/core/tabbedToolbox';
 
 /**
  *
@@ -16,21 +18,50 @@ export const WorkspacePage = () => {
   const { workspaceId } = useParams();
   const { isPending, isError } = useGetWorkspace(workspaceId as string);
   usePreventLeaveWorkspacePage();
-  const { isCoachMarkOpen, openCoachMark, closeCoachMark } = useCoachMarkStore();
-
-  if (isError) {
-    return <NotFound />;
-  }
+  const { currentStep, isCoachMarkOpen, openCoachMark } = useCoachMarkStore();
+  const toolboxDiv = document.querySelector('.blocklyToolboxDiv');
 
   useLayoutEffect(() => {
     const isCoachMarkDismissed = localStorage.getItem('isCoachMarkDismissed');
 
     if (!isCoachMarkDismissed) {
       openCoachMark();
-    } else {
-      closeCoachMark();
     }
   }, []);
+
+  useEffect(() => {
+    const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    if (!workspace) {
+      return;
+    }
+
+    const toolbox = workspace.getToolbox() as TabbedToolbox;
+
+    if (!toolbox) return;
+
+    switch (currentStep < 5) {
+      case 0:
+        toolbox.clickTab('html');
+        break;
+      case 1:
+        toolbox.clickTab('css');
+        break;
+      case 2:
+        toolbox.clickTab('html');
+    }
+
+    if (toolboxDiv) {
+      if (currentStep <= 1) {
+        toolboxDiv.classList.add('coachMarkHighlight');
+      } else {
+        toolboxDiv.classList.remove('coachMarkHighlight');
+      }
+    }
+  }, [currentStep, toolboxDiv]);
+
+  if (isError) {
+    return <NotFound />;
+  }
 
   return (
     <>

--- a/apps/client/src/shared/store/useCoachMarkStore.ts
+++ b/apps/client/src/shared/store/useCoachMarkStore.ts
@@ -12,6 +12,6 @@ export const useCoachMarkStore = create<TCoachMarkStore>()((set) => ({
   isCoachMarkOpen: true,
   currentStep: 0,
   openCoachMark: () => set({ isCoachMarkOpen: true, currentStep: 0 }),
-  closeCoachMark: () => set({ isCoachMarkOpen: false }),
+  closeCoachMark: () => set({ isCoachMarkOpen: false, currentStep: 5 }),
   setCurrentStep: (step) => set({ currentStep: step }),
 }));

--- a/apps/client/src/shared/utils/tags.ts
+++ b/apps/client/src/shared/utils/tags.ts
@@ -1,5 +1,3 @@
-// TODO: 위치 논의 필요 (shared or core)
-
 export const container = ['div', 'span', 'header', 'section', 'nav', 'main', 'article', 'footer'];
 export const text = [
   'p',

--- a/apps/client/src/widgets/workspace/CoachMark/CoachMark.tsx
+++ b/apps/client/src/widgets/workspace/CoachMark/CoachMark.tsx
@@ -1,16 +1,10 @@
-import { useEffect } from 'react';
 import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
 import { CircleButton } from '@/shared/ui';
-import * as Blockly from 'blockly/core';
-import TabbedToolbox from '@/core/tabbedToolbox';
 import { coachMarkContent } from '@/shared/utils';
 
 export const CoachMark = () => {
   const { currentStep, setCurrentStep, closeCoachMark } = useCoachMarkStore();
   const stepsLength = coachMarkContent.length;
-  const toolboxDiv = document.querySelector('.blocklyToolboxDiv');
-  // const blockCanvas = document.querySelector('.blocklyBlockCanvas');
-  // TODO: 사용자가이드 - 블록 하이라이팅
 
   const nextStep = () => {
     if (currentStep < stepsLength - 1) {
@@ -28,38 +22,6 @@ export const CoachMark = () => {
     localStorage.setItem('isCoachMarkDismissed', 'true');
     closeCoachMark();
   };
-
-  useEffect(() => {
-    const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-    if (!workspace) {
-      return;
-    }
-
-    const toolbox = workspace.getToolbox() as TabbedToolbox;
-
-    if (!toolbox) return;
-
-    switch (currentStep) {
-      case 0:
-        toolbox.clickTab('html');
-        break;
-      case 1:
-        toolbox.clickTab('css');
-        break;
-      case 2:
-        toolbox.clickTab('html');
-    }
-
-    if (toolboxDiv) {
-      if (currentStep <= 1) {
-        toolboxDiv.classList.add('coachMarkHighlight');
-        // blockCanvas.classList.add('coachMarkHighlight');
-      } else {
-        toolboxDiv.classList.remove('coachMarkHighlight');
-        // blockCanvas.classList.remove('coachMarkHighlight');
-      }
-    }
-  }, [currentStep, toolboxDiv]);
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black bg-opacity-70">
@@ -83,7 +45,6 @@ export const CoachMark = () => {
               그만 보기
             </CircleButton>
 
-            {/* TODO: 이전 버튼 - 기능 구현 후 삭제 */}
             <CircleButton
               className="text-bold-sm h-8 w-16"
               onClick={prevStep}

--- a/apps/client/src/widgets/workspace/CoachMark/CoachMark.tsx
+++ b/apps/client/src/widgets/workspace/CoachMark/CoachMark.tsx
@@ -1,6 +1,9 @@
 import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
 import { CircleButton } from '@/shared/ui';
 import { coachMarkContent } from '@/shared/utils';
+import { useEffect } from 'react';
+import * as Blockly from 'blockly/core';
+import TabbedToolbox from '@/core/tabbedToolbox';
 
 export const CoachMark = () => {
   const { currentStep, setCurrentStep, closeCoachMark } = useCoachMarkStore();
@@ -22,6 +25,27 @@ export const CoachMark = () => {
     localStorage.setItem('isCoachMarkDismissed', 'true');
     closeCoachMark();
   };
+
+  useEffect(() => {
+    const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    if (!workspace) {
+      return;
+    }
+
+    const toolbox = workspace.getToolbox() as TabbedToolbox;
+    if (!toolbox) return;
+
+    switch (currentStep) {
+      case 0:
+        toolbox.clickTab('html');
+        break;
+      case 1:
+        toolbox.clickTab('css');
+        break;
+      case 2:
+        toolbox.clickTab('html');
+    }
+  }, [currentStep]);
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black bg-opacity-70">

--- a/apps/client/src/widgets/workspace/WorkspacePageHeader/WorkspacePageHeader.tsx
+++ b/apps/client/src/widgets/workspace/WorkspacePageHeader/WorkspacePageHeader.tsx
@@ -20,12 +20,11 @@ export const WorkspacePageHeader = () => {
       </div>
       <div className="flex gap-11">
         <button
-          className="text-medium-rg hover flex items-center gap-1 text-gray-300"
+          className="text-medium-rg hover flex items-center gap-1 text-gray-300 hover:text-gray-500"
           onClick={openCoachMark}
           aria-label="도움말 버튼"
         >
           도움말 <Question />
-          {/* TODO: hover시 효과 */}
         </button>
         <WorkspaceHeaderButtons />
       </div>


### PR DESCRIPTION
## 🔗 Linked Issue (#240 )

## 🙋‍ Summary (요약) 
- 사용자 가이드 그만두기 클릭시 전역 상태 초기화
- 디자인 디테일

## 😎 Description (변경사항)
![Dec-06-2024 07-33-31](https://github.com/user-attachments/assets/06072c1a-cb65-4af6-aeac-9fbdaa871c1f)


## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
z-index 해제가 제대로 동작하지 않아 발생한 문제였습니다.
- 그만두기 클릭시 단계 상태값 초기화
   3, 4, 5 단계는 상태값 초기화하여 z-index 제대로 리셋되었습니다.
   하지만 1, 2 단계는 여전히 z-index가 남아있었습니다.

- 코치마크 외부에서 전역상태 업데이트
  문제는 코치마크 동작 제어를 내부에서 했던 점입니다. 코치마크가 닫히면서 하이라이팅 스타일 관련 클래스를 제대로 해제하지 못했던 것입니다.
  그래서 관련 로직을 상위에서 동작하도록 하여 해결하였습니다.
 
## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
